### PR TITLE
fix(reducer): add original entityState spreads for loads (so we don't…

### DIFF
--- a/projects/ngrx-auto-entity/package.json
+++ b/projects/ngrx-auto-entity/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.10",
+  "version": "0.0.11",
   "name": "@briebug/ngrx-auto-entity",
   "description": "An automatic entity action library for NgRX",
   "keywords": [

--- a/projects/ngrx-auto-entity/src/lib/reducer.spec.ts
+++ b/projects/ngrx-auto-entity/src/lib/reducer.spec.ts
@@ -180,7 +180,7 @@ describe('NgRX Auto-Entity: Reducer', () => {
           },
           ids: [1, 2, 3],
           currentPage: 1,
-          totalCount: 10
+          totalPageableCount: 10
         }
       };
       const rootReducer = jest.fn();
@@ -250,7 +250,7 @@ describe('NgRX Auto-Entity: Reducer', () => {
           },
           ids: [1, 2, 3],
           currentRange: { first: 1, last: 3 },
-          totalCount: 10
+          totalPageableCount: 10
         }
       };
       const rootReducer = jest.fn();

--- a/projects/ngrx-auto-entity/src/lib/reducer.ts
+++ b/projects/ngrx-auto-entity/src/lib/reducer.ts
@@ -151,6 +151,7 @@ export function autoEntityReducer(reducer: ActionReducer<any>, state, action: En
       const reduced = {
         ...state,
         [stateName]: {
+          ...entityState,
           entities: loadedEntities.reduce(
             (entities, entity) => ({
               ...entities,
@@ -198,6 +199,7 @@ export function autoEntityReducer(reducer: ActionReducer<any>, state, action: En
       const reduced = {
         ...state,
         [stateName]: {
+          ...entityState,
           entities: loadedEntities.reduce(
             (entities, entity) => ({
               ...entities,
@@ -245,6 +247,7 @@ export function autoEntityReducer(reducer: ActionReducer<any>, state, action: En
       const reduced = {
         ...state,
         [stateName]: {
+          ...entityState,
           entities: {
             ...(entityState.entities || {}),
             ...loadedEntities.reduce(


### PR DESCRIPTION
… lose other state, such as currentEntityKey)