### PR TITLE
feat: delete entities by key (id)

### DIFF
--- a/projects/ngrx-auto-entity/src/index.ts
+++ b/projects/ngrx-auto-entity/src/index.ts
@@ -74,9 +74,15 @@ export {
   Delete,
   DeleteFailure,
   DeleteSuccess,
+  DeleteByKey,
+  DeleteByKeyFailure,
+  DeleteByKeySuccess,
   DeleteMany,
   DeleteManyFailure,
   DeleteManySuccess,
+  DeleteManyByKeys,
+  DeleteManyByKeysFailure,
+  DeleteManyByKeysSuccess,
   Select,
   SelectByKey,
   SelectMany,
@@ -126,7 +132,9 @@ export {
   IEntityPageRef,
   IEntityError,
   IAutoEntityService,
-  IEntityRef
+  IEntityRef,
+  IEntityIdentityRef,
+  IEntityIdentitiesRef
 } from './lib/service';
 
 export {
@@ -144,7 +152,9 @@ export {
   ReplaceEffect,
   ReplaceManyEffect,
   DeleteEffect,
+  DeleteByKeyEffect,
   DeleteManyEffect,
+  DeleteManyByKeysEffect,
   EntityEffects,
   ExtraEffects
 } from './lib/effects.default';

--- a/projects/ngrx-auto-entity/src/lib/actions.ts
+++ b/projects/ngrx-auto-entity/src/lib/actions.ts
@@ -63,6 +63,14 @@ export enum EntityActionTypes {
   DeleteManySuccess = '[Entity] (Generic) Delete Many: Success',
   DeleteManyFailure = '[Entity] (Generic) Delete Many: Failure',
 
+  DeleteByKey = '[Entity] (Generic) Delete by key',
+  DeleteByKeySuccess = '[Entity] (Generic) Delete by key: Success',
+  DeleteByKeyFailure = '[Entity] (Generic) Delete by key: Failure',
+
+  DeleteManyByKeys = '[Entity] (Generic) Delete many by keys',
+  DeleteManyByKeysSuccess = '[Entity] (Generic) Delete many by keys: Success',
+  DeleteManyByKeysFailure = '[Entity] (Generic) Delete many by keys: Failure',
+
   Clear = '[Entity] (Generic) Clear',
 
   Select = '[Entity] (Generic) Select',
@@ -440,6 +448,48 @@ export class DeleteManyFailure<TModel> extends EntityAction<TModel> {
 }
 
 /**
+ * Deletes a single entity by key, corresponding to HTTP DELETE operation
+ */
+export class DeleteByKey<TModel> extends EntityAction<TModel> {
+  constructor(type: new () => TModel, public key: EntityIdentity, public criteria?: any, correlationId?: string) {
+    super(type, EntityActionTypes.DeleteByKey, correlationId);
+  }
+}
+
+export class DeleteByKeySuccess<TModel> extends EntityAction<TModel> {
+  constructor(type: new () => TModel, public key: EntityIdentity, correlationId?: string) {
+    super(type, EntityActionTypes.DeleteByKeySuccess, correlationId);
+  }
+}
+
+export class DeleteByKeyFailure<TModel> extends EntityAction<TModel> {
+  constructor(type: new () => TModel, public error: any, correlationId?: string) {
+    super(type, EntityActionTypes.DeleteByKeyFailure, correlationId);
+  }
+}
+
+/**
+ * Deletes many entities, corresponding to HTTP DELETE operation
+ */
+export class DeleteManyByKeys<TModel> extends EntityAction<TModel> {
+  constructor(type: new () => TModel, public keys: EntityIdentity[], public criteria?: any, correlationId?: string) {
+    super(type, EntityActionTypes.DeleteManyByKeys, correlationId);
+  }
+}
+
+export class DeleteManyByKeysSuccess<TModel> extends EntityAction<TModel> {
+  constructor(type: new () => TModel, public keys: EntityIdentity[], correlationId?: string) {
+    super(type, EntityActionTypes.DeleteManyByKeysSuccess, correlationId);
+  }
+}
+
+export class DeleteManyByKeysFailure<TModel> extends EntityAction<TModel> {
+  constructor(type: new () => TModel, public error: any, correlationId?: string) {
+    super(type, EntityActionTypes.DeleteManyByKeysFailure, correlationId);
+  }
+}
+
+/**
  * Clears all entities for this model from state
  */
 export class Clear<TModel> extends EntityAction<TModel> {
@@ -724,6 +774,12 @@ export type EntityActions<TModel> =
   | DeleteMany<TModel>
   | DeleteManyFailure<TModel>
   | DeleteManySuccess<TModel>
+  | DeleteByKey<TModel>
+  | DeleteByKeyFailure<TModel>
+  | DeleteByKeySuccess<TModel>
+  | DeleteManyByKeys<TModel>
+  | DeleteManyByKeysFailure<TModel>
+  | DeleteManyByKeysSuccess<TModel>
   | Clear<TModel>
   | Select<TModel>
   | SelectByKey<TModel>
@@ -783,6 +839,12 @@ export const isEntityActionInstance = (action: IEntityAction): boolean =>
   action instanceof DeleteMany ||
   action instanceof DeleteManySuccess ||
   action instanceof DeleteManyFailure ||
+  action instanceof DeleteByKey ||
+  action instanceof DeleteByKeySuccess ||
+  action instanceof DeleteByKeyFailure ||
+  action instanceof DeleteManyByKeys ||
+  action instanceof DeleteManyByKeysSuccess ||
+  action instanceof DeleteManyByKeysFailure ||
   action instanceof Clear ||
   action instanceof Select ||
   action instanceof SelectByKey ||

--- a/projects/ngrx-auto-entity/src/lib/decorators/entity.spec.ts
+++ b/projects/ngrx-auto-entity/src/lib/decorators/entity.spec.ts
@@ -81,6 +81,8 @@ describe('Utility: all', () => {
       [EntityActionTypes.ReplaceMany]: true,
       [EntityActionTypes.Delete]: true,
       [EntityActionTypes.DeleteMany]: true,
+      [EntityActionTypes.DeleteByKey]: true,
+      [EntityActionTypes.DeleteManyByKeys]: true,
       [EntityActionTypes.Select]: true,
       [EntityActionTypes.SelectMany]: true,
       [EntityActionTypes.SelectByKey]: true,
@@ -110,6 +112,8 @@ describe('Utility: all', () => {
       [EntityActionTypes.ReplaceMany]: true,
       [EntityActionTypes.Delete]: true,
       [EntityActionTypes.DeleteMany]: true,
+      [EntityActionTypes.DeleteByKey]: true,
+      [EntityActionTypes.DeleteManyByKeys]: true,
       [EntityActionTypes.Select]: true,
       [EntityActionTypes.SelectMany]: true,
       [EntityActionTypes.SelectByKey]: true,
@@ -193,6 +197,8 @@ describe('Utility: curd', () => {
       [EntityActionTypes.ReplaceMany]: true,
       [EntityActionTypes.Delete]: true,
       [EntityActionTypes.DeleteMany]: true,
+      [EntityActionTypes.DeleteByKey]: true,
+      [EntityActionTypes.DeleteManyByKeys]: true,
       except: expect.any(Function)
     };
     expect(curd).toEqual(EXTRA);
@@ -207,7 +213,9 @@ describe('Utility: curd', () => {
       [EntityActionTypes.Replace]: true,
       [EntityActionTypes.ReplaceMany]: true,
       [EntityActionTypes.Delete]: false,
-      [EntityActionTypes.DeleteMany]: true
+      [EntityActionTypes.DeleteMany]: true,
+      [EntityActionTypes.DeleteByKey]: true,
+      [EntityActionTypes.DeleteManyByKeys]: true
     };
     expect(curd.except(EntityActionTypes.Create, EntityActionTypes.Delete)).toEqual(EXCEPTED);
   });

--- a/projects/ngrx-auto-entity/src/lib/decorators/entity.ts
+++ b/projects/ngrx-auto-entity/src/lib/decorators/entity.ts
@@ -39,7 +39,9 @@ const CURD_EFFECTS_EXCLUSION = Object.freeze({
   [EntityActionTypes.Replace]: true,
   [EntityActionTypes.ReplaceMany]: true,
   [EntityActionTypes.Delete]: true,
-  [EntityActionTypes.DeleteMany]: true
+  [EntityActionTypes.DeleteMany]: true,
+  [EntityActionTypes.DeleteByKey]: true,
+  [EntityActionTypes.DeleteManyByKeys]: true
 });
 
 const LOAD_EFFECTS_EXCLUSION = Object.freeze({

--- a/projects/ngrx-auto-entity/src/lib/effects.default.ts
+++ b/projects/ngrx-auto-entity/src/lib/effects.default.ts
@@ -2,46 +2,7 @@ import { Injectable } from '@angular/core';
 import { Actions, Effect } from '@ngrx/effects';
 import { Action } from '@ngrx/store';
 import { Observable } from 'rxjs';
-import {
-  Change,
-  Changed,
-  CreateFailure,
-  CreateManyFailure,
-  CreateManySuccess,
-  CreateSuccess,
-  DeleteFailure,
-  DeleteManyFailure,
-  DeleteManySuccess,
-  DeleteSuccess,
-  Deselected,
-  DeselectedMany,
-  Edit,
-  Edited,
-  EditEnded,
-  EndEdit,
-  EntityActionTypes,
-  LoadAllFailure,
-  LoadAllSuccess,
-  LoadFailure,
-  LoadManyFailure,
-  LoadManySuccess,
-  LoadPageFailure,
-  LoadPageSuccess,
-  LoadRangeFailure,
-  LoadRangeSuccess,
-  LoadSuccess,
-  ofEntityAction,
-  ReplaceFailure,
-  ReplaceManyFailure,
-  ReplaceManySuccess,
-  ReplaceSuccess,
-  Selected,
-  SelectedMany,
-  UpdateFailure,
-  UpdateManyFailure,
-  UpdateManySuccess,
-  UpdateSuccess
-} from './actions';
+import { EntityActionTypes, ofEntityAction } from './actions';
 import { EntityOperators } from './operators';
 
 /**
@@ -126,6 +87,18 @@ export class EntityEffects {
   deleteMany$ = this.actions$.pipe(
     ofEntityAction(EntityActionTypes.DeleteMany),
     this.ops.deleteMany()
+  );
+
+  @Effect()
+  deleteByKey$ = this.actions$.pipe(
+    ofEntityAction(EntityActionTypes.DeleteByKey),
+    this.ops.deleteByKey()
+  );
+
+  @Effect()
+  deleteManyByKeys$ = this.actions$.pipe(
+    ofEntityAction(EntityActionTypes.DeleteManyByKeys),
+    this.ops.deleteManyByKey()
   );
 
   constructor(private actions$: Actions, private ops: EntityOperators) {}
@@ -393,6 +366,28 @@ export class DeleteManyEffect {
 }
 
 @Injectable()
+export class DeleteByKeyEffect {
+  @Effect()
+  deleteByKey$ = this.actions$.pipe(
+    ofEntityAction(EntityActionTypes.DeleteByKey),
+    this.ops.deleteByKey()
+  );
+
+  constructor(private actions$: Actions, private ops: EntityOperators) {}
+}
+
+@Injectable()
+export class DeleteManyByKeysEffect {
+  @Effect()
+  deleteManyByKeys$ = this.actions$.pipe(
+    ofEntityAction(EntityActionTypes.DeleteManyByKeys),
+    this.ops.deleteManyByKey()
+  );
+
+  constructor(private actions$: Actions, private ops: EntityOperators) {}
+}
+
+@Injectable()
 export class CUDEffects {
   @Effect()
   create$: Observable<Action> = this.actions$.pipe(
@@ -440,6 +435,18 @@ export class CUDEffects {
   deleteMany$ = this.actions$.pipe(
     ofEntityAction(EntityActionTypes.DeleteMany),
     this.ops.deleteMany()
+  );
+
+  @Effect()
+  deleteByKey$ = this.actions$.pipe(
+    ofEntityAction(EntityActionTypes.DeleteByKey),
+    this.ops.deleteByKey()
+  );
+
+  @Effect()
+  deleteManyByKeys$ = this.actions$.pipe(
+    ofEntityAction(EntityActionTypes.DeleteManyByKeys),
+    this.ops.deleteManyByKey()
   );
 
   constructor(private actions$: Actions, private ops: EntityOperators) {}

--- a/projects/ngrx-auto-entity/src/lib/operators.ts
+++ b/projects/ngrx-auto-entity/src/lib/operators.ts
@@ -13,8 +13,14 @@ import {
   CreateManySuccess,
   CreateSuccess,
   Delete,
+  DeleteByKey,
+  DeleteByKeyFailure,
+  DeleteByKeySuccess,
   DeleteFailure,
   DeleteMany,
+  DeleteManyByKeys,
+  DeleteManyByKeysFailure,
+  DeleteManyByKeysSuccess,
   DeleteManyFailure,
   DeleteManySuccess,
   DeleteSuccess,
@@ -66,7 +72,15 @@ import {
   UpdateSuccess
 } from './actions';
 import { shouldApplyEffect } from './decorators/entity';
-import { IEntityError, IEntityPageRef, IEntityRangeRef, IEntityRef, NgrxAutoEntityService } from './service';
+import {
+  IEntityError,
+  IEntityIdentitiesRef,
+  IEntityIdentityRef,
+  IEntityPageRef,
+  IEntityRangeRef,
+  IEntityRef,
+  NgrxAutoEntityService
+} from './service';
 
 export const handleError = <TModel, TErrorAction>(
   error: IEntityError<TModel>,
@@ -312,6 +326,42 @@ export class EntityOperators {
             ),
             catchError((error: IEntityError<TModel>) =>
               handleError(error, new DeleteManyFailure<TModel>(error.info.modelType, error.err, correlationId))
+            )
+          );
+        })
+      );
+  }
+
+  deleteByKey<TModel>() {
+    return (source: Observable<DeleteByKey<TModel>>) =>
+      source.pipe(
+        shouldApplyEffect(),
+        mergeMap(({ info, key, criteria, correlationId }) => {
+          return this.entityService.deleteByKey<TModel>(info, key, criteria).pipe(
+            map(
+              (ref: IEntityIdentityRef) =>
+                new DeleteByKeySuccess<TModel>(ref.info.modelType, ref.entityIdentity, correlationId)
+            ),
+            catchError((error: IEntityError<TModel>) =>
+              handleError(error, new DeleteByKeyFailure<TModel>(error.info.modelType, error.err, correlationId))
+            )
+          );
+        })
+      );
+  }
+
+  deleteManyByKey<TModel>() {
+    return (source: Observable<DeleteManyByKeys<TModel>>) =>
+      source.pipe(
+        shouldApplyEffect(),
+        mergeMap(({ info, keys, criteria, correlationId }) => {
+          return this.entityService.deleteManyByKey<TModel>(info, keys, criteria).pipe(
+            map(
+              (ref: IEntityIdentitiesRef) =>
+                new DeleteManyByKeysSuccess<TModel>(ref.info.modelType, ref.entityIdentities, correlationId)
+            ),
+            catchError((error: IEntityError<TModel>) =>
+              handleError(error, new DeleteManyByKeysFailure<TModel>(error.info.modelType, error.err, correlationId))
             )
           );
         })

--- a/projects/ngrx-auto-entity/src/lib/reducer.spec.ts
+++ b/projects/ngrx-auto-entity/src/lib/reducer.spec.ts
@@ -3,6 +3,8 @@ import 'jest-extended';
 import {
   CreateManySuccess,
   CreateSuccess,
+  DeleteByKeySuccess,
+  DeleteManyByKeysSuccess,
   DeleteManySuccess,
   DeleteSuccess,
   Deselect,
@@ -591,6 +593,54 @@ describe('NgRX Auto-Entity: Reducer', () => {
       const rootReducer = jest.fn();
       const metaReducer = autoEntityMetaReducer(rootReducer);
       const newState = metaReducer(state, new DeleteManySuccess(TestEntity, [{ identity: 1 }, { identity: 3 }]));
+
+      expect(newState).toEqual({
+        testEntity: {
+          entities: {
+            2: { identity: 2 }
+          },
+          ids: [2],
+          isDeleting: false,
+          deletedAt: expect.toBeDate()
+        }
+      });
+    });
+
+    it(`should reduce DeleteByKeySuccess and remove existing entity from state`, () => {
+      const state = {
+        testEntity: {
+          entities: { 1: { identity: 1 } },
+          ids: [1]
+        }
+      };
+      const rootReducer = jest.fn();
+      const metaReducer = autoEntityMetaReducer(rootReducer);
+      const newState = metaReducer(state, new DeleteByKeySuccess(TestEntity, 1));
+
+      expect(newState).toEqual({
+        testEntity: {
+          entities: {},
+          ids: [],
+          isDeleting: false,
+          deletedAt: expect.toBeDate()
+        }
+      });
+    });
+
+    it(`should reduce DeleteManyByKeySuccess and remove existing entities from state`, () => {
+      const state = {
+        testEntity: {
+          entities: {
+            2: { identity: 2 },
+            1: { identity: 1 },
+            3: { identity: 3 }
+          },
+          ids: [1, 2, 3]
+        }
+      };
+      const rootReducer = jest.fn();
+      const metaReducer = autoEntityMetaReducer(rootReducer);
+      const newState = metaReducer(state, new DeleteManyByKeysSuccess(TestEntity, [1, 3]));
 
       expect(newState).toEqual({
         testEntity: {

--- a/projects/ngrx-auto-entity/src/lib/reducer.ts
+++ b/projects/ngrx-auto-entity/src/lib/reducer.ts
@@ -4,6 +4,8 @@ import {
   Change,
   CreateManySuccess,
   CreateSuccess,
+  DeleteByKeySuccess,
+  DeleteManyByKeysSuccess,
   DeleteManySuccess,
   DeleteSuccess,
   DeselectMany,
@@ -561,6 +563,86 @@ export function autoEntityReducer(reducer: ActionReducer<any>, state, action: En
           )
         },
         ids: [...entityState.ids.filter(sid => !deletedIds.some(did => did === sid))],
+        isDeleting: false,
+        deletedAt: new Date()
+      };
+
+      const next = setNewState(featureName, stateName, state, newState);
+      return next;
+    }
+
+    case EntityActionTypes.DeleteByKey: {
+      const newState = {
+        ...entityState,
+        isDeleting: true
+      };
+
+      const next = setNewState(featureName, stateName, state, newState);
+      return next;
+    }
+    case EntityActionTypes.DeleteByKeyFailure: {
+      const newState = {
+        ...entityState,
+        isDeleting: false
+      };
+
+      const next = setNewState(featureName, stateName, state, newState);
+      return next;
+    }
+    case EntityActionTypes.DeleteByKeySuccess: {
+      const deleteKey = (action as DeleteByKeySuccess<any>).key;
+
+      // Better to NOT delete the entity key, but set it to undefined,
+      // to avoid re-generating the underlying runtime class (TODO: find and add link to V8 jit and runtime)
+      const newState = {
+        ...entityState,
+        entities: {
+          ...entityState.entities,
+          [deleteKey]: undefined
+        },
+        ids: entityState.ids.filter(eid => eid !== deleteKey),
+        isDeleting: false,
+        deletedAt: new Date()
+      };
+
+      const next = setNewState(featureName, stateName, state, newState);
+      return next;
+    }
+
+    case EntityActionTypes.DeleteManyByKeys: {
+      const newState = {
+        ...entityState,
+        isDeleting: true
+      };
+
+      const next = setNewState(featureName, stateName, state, newState);
+      return next;
+    }
+    case EntityActionTypes.DeleteManyByKeysFailure: {
+      const newState = {
+        ...entityState,
+        isDeleting: false
+      };
+
+      const next = setNewState(featureName, stateName, state, newState);
+      return next;
+    }
+    case EntityActionTypes.DeleteManyByKeysSuccess: {
+      const deleteKeys = (action as DeleteManyByKeysSuccess<any>).keys;
+
+      const newState = {
+        ...entityState,
+        entities: {
+          ...(entityState.entities || {}),
+          ...deleteKeys.reduce(
+            (entities, key) => ({
+              ...entities,
+              [key]: undefined
+            }),
+            {}
+          )
+        },
+        ids: [...entityState.ids.filter(sid => !deleteKeys.some(did => did === sid))],
         isDeleting: false,
         deletedAt: new Date()
       };

--- a/projects/ngrx-auto-entity/src/lib/service.spec.ts
+++ b/projects/ngrx-auto-entity/src/lib/service.spec.ts
@@ -21,6 +21,7 @@ import {
   resolveService,
   resolveServiceDeep
 } from './service';
+import { EntityIdentity } from './util';
 
 export class TestModel {
   id: number;
@@ -147,6 +148,26 @@ export class TestModelService implements IAutoEntityService<TestModel> {
       return throwError({ message: 'Service not found' });
     } else {
       return of(entity);
+    }
+  }
+
+  deleteByKey(entityInfo: IEntityInfo, entityIdentity: EntityIdentity, criteria?: any): Observable<EntityIdentity> {
+    if (entityInfo.modelName !== 'TestModel') {
+      return throwError({ message: 'Service not found' });
+    } else {
+      return of(entityIdentity);
+    }
+  }
+
+  deleteManyByKeys(
+    entityInfo: IEntityInfo,
+    entityIdentities: EntityIdentity[],
+    criteria?: any
+  ): Observable<EntityIdentity[]> {
+    if (entityInfo.modelName !== 'TestModel') {
+      return throwError({ message: 'Service not found' });
+    } else {
+      return of(entityIdentities);
     }
   }
 }
@@ -561,6 +582,52 @@ describe('NgRX Auto-Entity: Service', () => {
         test('should throw an error when the service is not found', done => {
           entityService
             .delete(badEntityInfo, entity)
+            .pipe(
+              catchError(err => {
+                expect(err).toEqual({ info: badEntityInfo, err: { message: 'Service not found' } });
+                return of(err);
+              })
+            )
+            .subscribe(() => {
+              done();
+            });
+        });
+      });
+
+      describe('deleteByKey', () => {
+        test('should return a valid EntityIdentityRef on successful delete', done => {
+          entityService.deleteByKey(entityInfo, entity.id).subscribe(entityIdentityRef => {
+            expect(entityIdentityRef).toEqual({ info: entityInfo, entityIdentity: entity.id });
+            done();
+          });
+        });
+
+        test('should throw an error when the service is not found', done => {
+          entityService
+            .deleteByKey(badEntityInfo, entity.id)
+            .pipe(
+              catchError(err => {
+                expect(err).toEqual({ info: badEntityInfo, err: { message: 'Service not found' } });
+                return of(err);
+              })
+            )
+            .subscribe(() => {
+              done();
+            });
+        });
+      });
+
+      describe('deleteManyByKeys', () => {
+        test('should return a valid EntityIdentitiesRef on successful delete', done => {
+          entityService.deleteManyByKey(entityInfo, [entity.id]).subscribe(entityIdentitiesRef => {
+            expect(entityIdentitiesRef).toEqual({ info: entityInfo, entityIdentities: [entity.id] });
+            done();
+          });
+        });
+
+        test('should throw an error when the service is not found', done => {
+          entityService
+            .deleteManyByKey(badEntityInfo, [entity.id])
             .pipe(
               catchError(err => {
                 expect(err).toEqual({ info: badEntityInfo, err: { message: 'Service not found' } });

--- a/projects/ngrx-auto-entity/src/lib/service.ts
+++ b/projects/ngrx-auto-entity/src/lib/service.ts
@@ -6,10 +6,21 @@ import { pascalCase } from '../util/case';
 import { IEntityInfo } from './actions';
 import { IPageInfo, IRangeInfo, Page, Range } from './models';
 import { IAutoEntityService } from './service';
+import { EntityIdentity } from './util';
 
 export interface IEntityRef<TModel> {
   info: IEntityInfo;
   entity: TModel;
+}
+
+export interface IEntityIdentityRef {
+  info: IEntityInfo;
+  entityIdentity: EntityIdentity;
+}
+
+export interface IEntityIdentitiesRef {
+  info: IEntityInfo;
+  entityIdentities: EntityIdentity[];
 }
 
 export interface IEntityError<TModel> {
@@ -62,6 +73,14 @@ export interface IAutoEntityService<TModel> {
   delete?(entityInfo: IEntityInfo, entity: TModel, criteria?: any): Observable<TModel>;
 
   deleteMany?(entityInfo: IEntityInfo, entities: TModel[], criteria?: any): Observable<TModel[]>;
+
+  deleteByKey?(entityInfo: IEntityInfo, key: EntityIdentity, criteria?: any): Observable<EntityIdentity>;
+
+  deleteManyByKeys?(
+    entityInfo: IEntityInfo,
+    keys: EntityIdentity[],
+    criteria?: any
+  ): Observable<EntityIdentity[]>;
 }
 
 export const notImplemented = (method: string, entityInfo: IEntityInfo): string =>
@@ -298,6 +317,34 @@ export class NgrxAutoEntityService {
       this.injector,
       service => service.deleteMany(entityInfo, entities, criteria),
       deleted => ({ info: entityInfo, entity: deleted })
+    );
+  }
+
+  deleteByKey<TModel>(
+    entityInfo: IEntityInfo,
+    key: EntityIdentity,
+    criteria?: any
+  ): Observable<IEntityIdentityRef> {
+    return callService<TModel, EntityIdentity, IEntityIdentityRef>(
+      'deleteByKey',
+      entityInfo,
+      this.injector,
+      service => service.deleteByKey(entityInfo, key, criteria),
+      deletedKey => ({ info: entityInfo, entityIdentity: deletedKey })
+    );
+  }
+
+  deleteManyByKey<TModel>(
+    entityInfo: IEntityInfo,
+    keys: EntityIdentity[],
+    criteria?: any
+  ): Observable<IEntityIdentitiesRef> {
+    return callService<TModel, EntityIdentity[], IEntityIdentitiesRef>(
+      'deleteManyByKeys',
+      entityInfo,
+      this.injector,
+      service => service.deleteManyByKeys(entityInfo, keys, criteria),
+      deletedKeys => ({ info: entityInfo, entityIdentities: deletedKeys })
     );
   }
 }

--- a/projects/ngrx-auto-entity/src/lib/service.ts
+++ b/projects/ngrx-auto-entity/src/lib/service.ts
@@ -76,11 +76,7 @@ export interface IAutoEntityService<TModel> {
 
   deleteByKey?(entityInfo: IEntityInfo, key: EntityIdentity, criteria?: any): Observable<EntityIdentity>;
 
-  deleteManyByKeys?(
-    entityInfo: IEntityInfo,
-    keys: EntityIdentity[],
-    criteria?: any
-  ): Observable<EntityIdentity[]>;
+  deleteManyByKeys?(entityInfo: IEntityInfo, keys: EntityIdentity[], criteria?: any): Observable<EntityIdentity[]>;
 }
 
 export const notImplemented = (method: string, entityInfo: IEntityInfo): string =>
@@ -320,11 +316,7 @@ export class NgrxAutoEntityService {
     );
   }
 
-  deleteByKey<TModel>(
-    entityInfo: IEntityInfo,
-    key: EntityIdentity,
-    criteria?: any
-  ): Observable<IEntityIdentityRef> {
+  deleteByKey<TModel>(entityInfo: IEntityInfo, key: EntityIdentity, criteria?: any): Observable<IEntityIdentityRef> {
     return callService<TModel, EntityIdentity, IEntityIdentityRef>(
       'deleteByKey',
       entityInfo,

--- a/projects/ngrx-auto-entity/src/lib/util.ts
+++ b/projects/ngrx-auto-entity/src/lib/util.ts
@@ -7,7 +7,9 @@ import {
   Create,
   CreateMany,
   Delete,
+  DeleteByKey,
   DeleteMany,
+  DeleteManyByKeys,
   Deselect,
   DeselectAll,
   DeselectMany,
@@ -286,6 +288,10 @@ export interface IEntityFacade<TModel> {
 
   deleteMany(entities: TModel[], criteria?: any): void;
 
+  deleteByKey(key: EntityIdentity, criteria?: any): void;
+
+  deleteManyByKeys(keys: EntityIdentity[], criteria?: any): void;
+
   clear(): void;
 }
 
@@ -493,6 +499,14 @@ export const buildFacade = <TModel, TParentState>(selectors: ISelectorMap<TParen
 
     deleteMany(entities: TModel[], criteria?: any): void {
       this.store.dispatch(new DeleteMany(this.modelType, entities, criteria));
+    }
+
+    deleteByKey(key: string | number, criteria?: any): void {
+      this.store.dispatch(new DeleteByKey(this.modelType, key, criteria));
+    }
+
+    deleteManyByKeys(keys: EntityIdentity[], criteria?: any): void {
+      this.store.dispatch(new DeleteManyByKeys(this.modelType, keys, criteria));
     }
 
     clear(): void {

--- a/src/app/+products/components/products-table/products-table.component.html
+++ b/src/app/+products/components/products-table/products-table.component.html
@@ -41,7 +41,11 @@
       </mat-cell>
     </ng-container>
     <mat-header-row *matHeaderRowDef="columnsToDisplay"></mat-header-row>
-    <mat-row *matRowDef="let product; columns: columnsToDisplay"></mat-row>
+    <mat-row
+      *matRowDef="let product; columns: columnsToDisplay"
+      [class.selected]="selection.isSelected(product)"
+      (click)="selection.toggle(product)"
+    ></mat-row>
   </mat-table>
   <mat-paginator [pageSizeOptions]="[5, 10, 25, 100]" [pageSize]="10" showFirstLastButtons></mat-paginator>
 </div>

--- a/src/app/+products/components/products-table/products-table.component.scss
+++ b/src/app/+products/components/products-table/products-table.component.scss
@@ -4,7 +4,7 @@
   width: 100%;
 }
 
-mat-row:hover {
+mat-row:hover, mat-row.selected {
   background-color: mat-color($mat-grey, 200);
   cursor: pointer;
 }

--- a/src/app/+products/components/products-table/products-table.component.ts
+++ b/src/app/+products/components/products-table/products-table.component.ts
@@ -22,6 +22,10 @@ import { Product } from '../../../models';
 })
 export class ProductsTableComponent implements OnChanges, OnInit, OnDestroy {
   @Input() products: Product[];
+  @Input() set selectedProducts(val: Product[]) {
+    this.selection.clear();
+    this.selection.select(...val);
+  }
   @Output() delete = new EventEmitter<Product>();
   @Output() edit = new EventEmitter<Product>();
   @Output() select = new EventEmitter<Product[]>();

--- a/src/app/+products/containers/products/products.component.html
+++ b/src/app/+products/containers/products/products.component.html
@@ -1,7 +1,13 @@
 <div fxLayout="column" fxLayoutAlign="start stretch" class="products">
   <h2>Products</h2>
-  <div class="actions" fxLayout="row" fxLayoutAlign="end">
+  <div class="actions" fxLayout="row" fxLayoutAlign="end" fxLayoutGap="5px">
+    <a mat-stroked-button (click)="bulkDelete()" [disabled]="!selectedProducts?.length">Bulk Delete</a>
     <a mat-stroked-button routerLink="add" color="primary">Add Product</a>
   </div>
-  <app-products-table [products]="products$ | async" (delete)="onDelete($event)" (edit)="onEdit($event)"></app-products-table>
+  <app-products-table
+    [products]="products$ | async"
+    (select)="onSelect($event)"
+    (delete)="onDelete($event)"
+    (edit)="onEdit($event)"
+  ></app-products-table>
 </div>

--- a/src/app/+products/containers/products/products.component.html
+++ b/src/app/+products/containers/products/products.component.html
@@ -6,6 +6,7 @@
   </div>
   <app-products-table
     [products]="products$ | async"
+    [selectedProducts]="selectedProducts"
     (select)="onSelect($event)"
     (delete)="onDelete($event)"
     (edit)="onEdit($event)"

--- a/src/app/+products/containers/products/products.component.ts
+++ b/src/app/+products/containers/products/products.component.ts
@@ -12,12 +12,24 @@ import { Product } from '../../../models';
 })
 export class ProductsComponent implements OnInit {
   products$: Observable<Product[]>;
+  selectedProducts: Product[] = [];
 
   constructor(private router: Router, private productFacade: ProductFacade) {}
 
   ngOnInit() {
     this.productFacade.loadAll();
     this.products$ = this.productFacade.all$;
+  }
+
+  bulkDelete() {
+    if (this.selectedProducts.length) {
+      const ids = this.selectedProducts.map(product => product.id);
+      this.productFacade.deleteManyByKeys(ids);
+    }
+  }
+
+  onSelect(products: Product[]) {
+    this.selectedProducts = products;
   }
 
   onDelete(product: Product) {

--- a/src/app/+products/containers/products/products.component.ts
+++ b/src/app/+products/containers/products/products.component.ts
@@ -24,7 +24,8 @@ export class ProductsComponent implements OnInit {
   bulkDelete() {
     if (this.selectedProducts.length) {
       const ids = this.selectedProducts.map(product => product.id);
-      this.productFacade.deleteManyByKeys(ids);
+      ids.length === 1 ? this.productFacade.deleteByKey(ids[0]) : this.productFacade.deleteManyByKeys(ids);
+      this.selectedProducts = [];
     }
   }
 

--- a/src/app/models/account.model.ts
+++ b/src/app/models/account.model.ts
@@ -1,5 +1,6 @@
-import { Key } from '@briebug/ngrx-auto-entity';
+import { Entity, Key } from '@briebug/ngrx-auto-entity';
 
+@Entity({ modelName: 'Account' })
 export class Account {
   @Key id: number;
   customerId: number;

--- a/src/app/models/customer.model.ts
+++ b/src/app/models/customer.model.ts
@@ -1,5 +1,6 @@
-import { Key } from '@briebug/ngrx-auto-entity';
+import { Entity, Key } from '@briebug/ngrx-auto-entity';
 
+@Entity({ modelName: 'Customer' })
 export class Customer {
   @Key id: number;
   name: string;

--- a/src/app/models/order-item.model.ts
+++ b/src/app/models/order-item.model.ts
@@ -1,5 +1,6 @@
-import { Key } from '@briebug/ngrx-auto-entity';
+import { Entity, Key } from '@briebug/ngrx-auto-entity';
 
+@Entity({ modelName: 'OrderItem' })
 export class OrderItem {
   @Key id: string;
   orderId: number;

--- a/src/app/models/order.model.ts
+++ b/src/app/models/order.model.ts
@@ -1,4 +1,4 @@
-import { Key } from '@briebug/ngrx-auto-entity';
+import { Entity, Key } from '@briebug/ngrx-auto-entity';
 
 export enum OrderStatus {
   pending = 'pending',
@@ -7,6 +7,7 @@ export enum OrderStatus {
   archived = 'archived'
 }
 
+@Entity({ modelName: 'Order' })
 export class Order {
   @Key id: number;
   accountId: number;

--- a/src/app/models/product.model.ts
+++ b/src/app/models/product.model.ts
@@ -1,5 +1,6 @@
-import { Key } from '@briebug/ngrx-auto-entity';
+import { Entity, Key } from '@briebug/ngrx-auto-entity';
 
+@Entity({ modelName: 'Product' })
 export class Product {
   @Key id: number;
   name: string;

--- a/src/app/services/entity.service.ts
+++ b/src/app/services/entity.service.ts
@@ -1,6 +1,6 @@
 import { HttpClient } from '@angular/common/http';
 import { Injectable } from '@angular/core';
-import { IAutoEntityService, IEntityInfo } from '@briebug/ngrx-auto-entity';
+import { EntityIdentity, IAutoEntityService, IEntityInfo } from '@briebug/ngrx-auto-entity';
 import { forkJoin, Observable, of } from 'rxjs';
 import { map } from 'rxjs/operators';
 import { environment } from '../../environments/environment';
@@ -40,5 +40,20 @@ export class EntityService implements IAutoEntityService<any> {
     return this.http
       .delete<any>(`${environment.API_BASE_URL}/${entityInfo.modelName.toLowerCase()}s/${entity.id}`)
       .pipe(map(() => entity));
+  }
+
+  deleteByKey(entityInfo: IEntityInfo, entityKey: string | number, criteria?: any): Observable<EntityIdentity> {
+    return this.http
+      .delete<any>(`${environment.API_BASE_URL}/${entityInfo.modelName.toLowerCase()}s/${entityKey}`)
+      .pipe(map(() => entityKey));
+  }
+
+  deleteManyByKeys(
+    entityInfo: IEntityInfo,
+    entityKeys: EntityIdentity[],
+    criteria?: any
+  ): Observable<EntityIdentity[]> {
+    const deleteRequests = entityKeys.map(key => this.deleteByKey(entityInfo, key, criteria));
+    return forkJoin(deleteRequests);
   }
 }


### PR DESCRIPTION
Allows consumers to delete entities by they primary key.

Testing:
- navigate to http://localhost:4200/products
- select multiple products from the table (multiselect has been enabled)
- click on the "Bulk Delete" button at the top
- if only 1 product is selected, the `deleteByKey` action will be used, otherwise it's `deleteManyByKeys`