### PR TITLE
fix: tracking timestamps and all/sorted selector efficiency

### DIFF
--- a/projects/ngrx-auto-entity/package.json
+++ b/projects/ngrx-auto-entity/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.5.0-alpha.5",
+  "version": "0.5.0-alpha.6",
   "name": "@briebug/ngrx-auto-entity",
   "description": "Automatic Entity State and Facades for NgRx. Simplifying reactive state!",
   "keywords": [

--- a/projects/ngrx-auto-entity/src/lib/util/selector-map-builder.spec.ts
+++ b/projects/ngrx-auto-entity/src/lib/util/selector-map-builder.spec.ts
@@ -1,0 +1,293 @@
+import { TestBed } from '@angular/core/testing';
+import { Store } from '@ngrx/store';
+import { MockStore, provideMockStore } from '@ngrx/store/testing';
+import { hot } from 'jasmine-marbles';
+import { ISelectorMap, Key } from '../..';
+import { IEntityState } from './entity-state';
+import {
+  buildSelectorMap,
+  mapToCreatedAt,
+  mapToDeletedAt,
+  mapToEntityArray,
+  mapToLoadedAt,
+  mapToSavedAt,
+  mapToSortedEntityArray
+} from './selector-map-builder';
+
+describe('mapToEntityArray()', () => {
+  it('should return empty array if entities is falsy', () => {
+    const entities = mapToEntityArray(null, []);
+    expect(entities).toEqual([]);
+  });
+
+  it('should return empty array if ids is falsy', () => {
+    const entities = mapToEntityArray({}, null);
+    expect(entities).toEqual([]);
+  });
+
+  it('should return empty array if ids is empty', () => {
+    const entities = mapToEntityArray({ 1: { id: 1, name: 'test' } }, []);
+    expect(entities).toEqual([]);
+  });
+
+  it('should return array of entity objects', () => {
+    const entities = mapToEntityArray({ 1: { id: 1, name: 'test 1' }, 2: { id: 2, name: 'test 2' } }, [1, 2]);
+    expect(entities).toEqual([{ id: 1, name: 'test 1' }, { id: 2, name: 'test 2' }]);
+  });
+});
+
+describe('mapToSortedEntityArray()', () => {
+  const compare = (a, b) => a.id - b.id;
+
+  it('should return empty array if all array is falsy', () => {
+    const entities = mapToSortedEntityArray(null, compare);
+    expect(entities).toEqual([]);
+  });
+
+  it('should return sorted array of entity objects', () => {
+    const all = [{ id: 2, name: 'test 2' }, { id: 1, name: 'test 1' }];
+    const entities = mapToSortedEntityArray(all, compare);
+    expect(entities).toEqual([{ id: 1, name: 'test 1' }, { id: 2, name: 'test 2' }]);
+  });
+});
+
+describe('mapToLoadedAt()', () => {
+  it('should return null if state falsy', () => {
+    const ts = mapToLoadedAt(null);
+    expect(ts).toBeNull();
+  });
+
+  it('should return null if loadedAt state is falsy', () => {
+    const ts = mapToLoadedAt({ entities: {}, ids: [] });
+    expect(ts).toBeNull();
+  });
+
+  it('should return Date', () => {
+    const now = Date.now();
+    const ts = mapToLoadedAt({ entities: {}, ids: [], loadedAt: now });
+    expect(ts).toStrictEqual(new Date(now));
+  });
+});
+
+describe('mapToSavedAt()', () => {
+  it('should return null if state falsy', () => {
+    const ts = mapToSavedAt(null);
+    expect(ts).toBeNull();
+  });
+
+  it('should return null if savedAt state is falsy', () => {
+    const ts = mapToSavedAt({ entities: {}, ids: [] });
+    expect(ts).toBeNull();
+  });
+
+  it('should return Date', () => {
+    const now = Date.now();
+    const ts = mapToSavedAt({ entities: {}, ids: [], savedAt: now });
+    expect(ts).toStrictEqual(new Date(now));
+  });
+});
+
+describe('mapToCreatedAt()', () => {
+  it('should return null if state falsy', () => {
+    const ts = mapToCreatedAt(null);
+    expect(ts).toBeNull();
+  });
+
+  it('should return null if createdAt state is falsy', () => {
+    const ts = mapToCreatedAt({ entities: {}, ids: [] });
+    expect(ts).toBeNull();
+  });
+
+  it('should return Date', () => {
+    const now = Date.now();
+    const ts = mapToCreatedAt({ entities: {}, ids: [], createdAt: now });
+    expect(ts).toStrictEqual(new Date(now));
+  });
+});
+
+describe('mapToDeletedAt()', () => {
+  it('should return null if state falsy', () => {
+    const ts = mapToDeletedAt(null);
+    expect(ts).toBeNull();
+  });
+
+  it('should return null if deletedAt state is falsy', () => {
+    const ts = mapToDeletedAt({ entities: {}, ids: [] });
+    expect(ts).toBeNull();
+  });
+
+  it('should return Date', () => {
+    const now = Date.now();
+    const ts = mapToDeletedAt({ entities: {}, ids: [], deletedAt: now });
+    expect(ts).toStrictEqual(new Date(now));
+  });
+});
+
+class Test {
+  @Key id: number;
+}
+
+interface ITestState {
+  test: IEntityState<Test>;
+}
+
+const testSelectorMap: ISelectorMap<ITestState, Test> = {
+  selectAll: expect.any(Function),
+  selectAllSorted: expect.any(Function),
+  selectEntities: expect.any(Function),
+  selectIds: expect.any(Function),
+  selectTotal: expect.any(Function),
+  selectCurrentEntity: expect.any(Function),
+  selectCurrentEntityKey: expect.any(Function),
+  selectCurrentEntities: expect.any(Function),
+  selectCurrentEntitiesKeys: expect.any(Function),
+  selectEditedEntity: expect.any(Function),
+  selectIsDirty: expect.any(Function),
+  selectCurrentPage: expect.any(Function),
+  selectCurrentRange: expect.any(Function),
+  selectTotalPageable: expect.any(Function),
+  selectIsLoading: expect.any(Function),
+  selectIsSaving: expect.any(Function),
+  selectIsDeleting: expect.any(Function),
+  selectLoadedAt: expect.any(Function),
+  selectSavedAt: expect.any(Function),
+  selectCreatedAt: expect.any(Function),
+  selectDeletedAt: expect.any(Function)
+};
+
+describe('buildSelectorMap()', () => {
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [
+        provideMockStore({
+          initialState: {
+            test: {
+              entities: {},
+              ids: []
+            }
+          }
+        })
+      ]
+    });
+  });
+
+  it('should create a selector map for the specified state', () => {
+    const selectorMap = buildSelectorMap<ITestState, IEntityState<Test>, Test, unknown>(state => state.test);
+    expect(selectorMap).toEqual(testSelectorMap);
+  });
+
+  describe('selectAll', () => {
+    it('should return empty array if no state', () => {
+      const store: MockStore<{}> = TestBed.get(Store);
+
+      store.setState({});
+
+      const getState = state => state.test;
+
+      const { selectAll } = buildSelectorMap<ITestState, IEntityState<Test>, Test, unknown>(getState);
+      const entities = store.select(selectAll);
+      expect(entities).toBeObservable(hot('a', { a: [] }));
+    });
+
+    it('should return empty array if no entities in state', () => {
+      const store: MockStore<ITestState> = TestBed.get(Store);
+
+      store.setState({
+        test: {
+          entities: {},
+          ids: []
+        }
+      });
+
+      const getState = state => state.test;
+
+      const { selectAll } = buildSelectorMap<ITestState, IEntityState<Test>, Test, unknown>(getState);
+      const entities = store.select(selectAll);
+      expect(entities).toBeObservable(hot('a', { a: [] }));
+    });
+
+    it('should return entities in state order', () => {
+      const store: MockStore<ITestState> = TestBed.get(Store);
+
+      const entity1 = { id: 1 };
+      const entity2 = { id: 2 };
+      store.setState({
+        test: {
+          entities: {
+            1: entity1,
+            2: entity2
+          },
+          ids: [2, 1]
+        }
+      });
+
+      const getState = state => state.test;
+
+      const { selectAll } = buildSelectorMap<ITestState, IEntityState<Test>, Test, unknown>(getState);
+      const entities = store.select(selectAll);
+      expect(entities).toBeObservable(hot('a', { a: [entity2, entity1] }));
+    });
+  });
+
+  describe('selectAllSorted', () => {
+    it('should return empty array if no state', () => {
+      const store: MockStore<{}> = TestBed.get(Store);
+
+      store.setState({});
+
+      const getState = state => state.test;
+
+      const { selectAllSorted } = buildSelectorMap<ITestState, IEntityState<Test>, Test, unknown>(
+        getState,
+        (a, b) => a.id - b.id
+      );
+      const entities = store.select(selectAllSorted);
+      expect(entities).toBeObservable(hot('a', { a: [] }));
+    });
+
+    it('should return empty array if no entities in state', () => {
+      const store: MockStore<ITestState> = TestBed.get(Store);
+
+      store.setState({
+        test: {
+          entities: {},
+          ids: []
+        }
+      });
+
+      const getState = state => state.test;
+
+      const { selectAllSorted } = buildSelectorMap<ITestState, IEntityState<Test>, Test, unknown>(
+        getState,
+        (a, b) => a.id - b.id
+      );
+      const entities = store.select(selectAllSorted);
+      expect(entities).toBeObservable(hot('a', { a: [] }));
+    });
+
+    it('should return entities in state order', () => {
+      const store: MockStore<ITestState> = TestBed.get(Store);
+
+      const entity1 = { id: 1 };
+      const entity2 = { id: 2 };
+      store.setState({
+        test: {
+          entities: {
+            1: entity1,
+            2: entity2
+          },
+          ids: [2, 1]
+        }
+      });
+
+      const getState = state => state.test;
+
+      const { selectAllSorted } = buildSelectorMap<ITestState, IEntityState<Test>, Test, unknown>(
+        getState,
+        (a, b) => a.id - b.id
+      );
+      const entities = store.select(selectAllSorted);
+      expect(entities).toBeObservable(hot('a', { a: [entity1, entity2] }));
+    });
+  });
+});

--- a/projects/ngrx-auto-entity/src/lib/util/selector-map-builder.ts
+++ b/projects/ngrx-auto-entity/src/lib/util/selector-map-builder.ts
@@ -5,13 +5,13 @@ import { ISelectorMap } from './selector-map';
 
 // prettier-ignore
 export const mapToEntityArray =
-  <TState extends IEntityState<TModel>, TModel, TExtra>(state: TState & TExtra): TModel[] =>
-    (!state || !state.ids || !state.entities ? [] : state.ids.map(id => state.entities[id]));
+  <TModel>(entities: IEntityDictionary<TModel>, ids: EntityIdentity[]): TModel[] =>
+    (!ids || !entities ? [] : ids.map(id => entities[id]));
 
 // prettier-ignore
 export const mapToSortedEntityArray =
-  <TState extends IEntityState<TModel>, TModel, TExtra>(state: TState & TExtra, compare: (a, b) => number): TModel[] =>
-    (!state || !state.ids || !state.entities ? [] : state.ids.map(id => state.entities[id])).sort(compare);
+  <TModel>(all: TModel[], compare: (a, b) => number): TModel[] =>
+    !all ? [] : all.sort(compare);
 
 // prettier-ignore
 export const mapToEntities =
@@ -93,48 +93,71 @@ export const mapToIsDeleting =
 // prettier-ignore
 export const mapToLoadedAt =
   <TState extends IEntityState<TModel>, TModel, TExtra>(state: TState & TExtra): Date | null =>
-    (!state ? null : new Date(state.loadedAt));
+    (!state || !state.loadedAt ? null : new Date(state.loadedAt));
 
 // prettier-ignore
 export const mapToSavedAt =
   <TState extends IEntityState<TModel>, TModel, TExtra>(state: TState & TExtra): Date | null =>
-    (!state ? null : new Date(state.savedAt));
+    (!state || !state.savedAt ? null : new Date(state.savedAt));
 
 // prettier-ignore
 export const mapToCreatedAt =
   <TState extends IEntityState<TModel>, TModel, TExtra>(state: TState & TExtra): Date | null =>
-    (!state ? null : new Date(state.createdAt));
+    (!state || !state.createdAt ? null : new Date(state.createdAt));
 
 // prettier-ignore
 export const mapToDeletedAt =
   <TState extends IEntityState<TModel>, TModel, TExtra>(state: TState & TExtra): Date | null =>
-    (!state ? null : new Date(state.deletedAt));
+    (!state || !state.deletedAt ? null : new Date(state.deletedAt));
 
 // prettier-ignore
 export const buildSelectorMap = <TParentState, TState extends IEntityState<TModel>, TModel, TExtra>(
   getState: Selector<TParentState, TState & TExtra> | MemoizedSelector<object | TParentState, TState & TExtra>,
   compareFn?: (a, b) => number
-): ISelectorMap<TParentState, TModel> =>
-  ({
-    selectAll: createSelector(getState, mapToEntityArray),
-    selectAllSorted: createSelector(getState, () => compareFn, mapToSortedEntityArray),
-    selectEntities: createSelector(getState, mapToEntities),
-    selectIds: createSelector(getState, mapToIds),
-    selectTotal: createSelector(getState, mapToTotal),
-    selectCurrentEntity: createSelector(getState, mapToCurrentEntity),
-    selectCurrentEntityKey: createSelector(getState, mapToCurrentEntityKey),
-    selectCurrentEntities: createSelector(getState, mapToCurrentEntities),
-    selectCurrentEntitiesKeys: createSelector(getState, mapToCurrentEntitiesKeys),
-    selectEditedEntity: createSelector(getState, mapToEditedEntity),
-    selectIsDirty: createSelector(getState, mapToIsDirty),
-    selectCurrentPage: createSelector(getState, mapToCurrentPage),
-    selectCurrentRange: createSelector(getState, mapToCurrentRange),
-    selectTotalPageable: createSelector(getState, mapToTotalPageable),
-    selectIsLoading: createSelector(getState, mapToIsLoading),
-    selectIsSaving: createSelector(getState, mapToIsSaving),
-    selectIsDeleting: createSelector(getState, mapToIsDeleting),
-    selectLoadedAt: createSelector(getState, mapToLoadedAt),
-    selectSavedAt: createSelector(getState, mapToSavedAt),
-    selectCreatedAt: createSelector(getState, mapToCreatedAt),
-    selectDeletedAt: createSelector(getState, mapToDeletedAt)
-  } as ISelectorMap<TParentState, TModel>);
+): ISelectorMap<TParentState, TModel> => {
+  const selectEntities = createSelector(getState, mapToEntities);
+  const selectIds = createSelector(getState, mapToIds);
+  const selectTotal = createSelector(getState, mapToTotal);
+  const selectAll = createSelector(selectEntities, selectIds, mapToEntityArray);
+  const selectAllSorted = createSelector(selectAll, () => compareFn, mapToSortedEntityArray);
+  const selectCurrentEntity = createSelector(getState, mapToCurrentEntity);
+  const selectCurrentEntityKey = createSelector(getState, mapToCurrentEntityKey);
+  const selectCurrentEntities = createSelector(getState, mapToCurrentEntities);
+  const selectCurrentEntitiesKeys = createSelector(getState, mapToCurrentEntitiesKeys);
+  const selectEditedEntity = createSelector(getState, mapToEditedEntity);
+  const selectIsDirty = createSelector(getState, mapToIsDirty);
+  const selectCurrentPage = createSelector(getState, mapToCurrentPage);
+  const selectCurrentRange = createSelector(getState, mapToCurrentRange);
+  const selectTotalPageable = createSelector(getState, mapToTotalPageable);
+  const selectIsLoading = createSelector(getState, mapToIsLoading);
+  const selectIsSaving = createSelector(getState, mapToIsSaving);
+  const selectIsDeleting = createSelector(getState, mapToIsDeleting);
+  const selectLoadedAt = createSelector(getState, mapToLoadedAt);
+  const selectSavedAt = createSelector(getState, mapToSavedAt);
+  const selectCreatedAt = createSelector(getState, mapToCreatedAt);
+  const selectDeletedAt = createSelector(getState, mapToDeletedAt);
+
+  return {
+    selectAll,
+    selectAllSorted,
+    selectEntities,
+    selectIds,
+    selectTotal,
+    selectCurrentEntity,
+    selectCurrentEntityKey,
+    selectCurrentEntities,
+    selectCurrentEntitiesKeys,
+    selectEditedEntity,
+    selectIsDirty,
+    selectCurrentPage,
+    selectCurrentRange,
+    selectTotalPageable,
+    selectIsLoading,
+    selectIsSaving,
+    selectIsDeleting,
+    selectLoadedAt,
+    selectSavedAt,
+    selectCreatedAt,
+    selectDeletedAt
+  } as ISelectorMap<TParentState, TModel>;
+};


### PR DESCRIPTION
 * Added check for timestamp property truthiness, return null if falsy
 * Refactored all and sorted selectors to be based off of other selectors for efficiency

Resolves #112 #113