### PR TITLE
fix/nae-115/failure action response

### DIFF
--- a/projects/ngrx-auto-entity/package.json
+++ b/projects/ngrx-auto-entity/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.5.0-alpha.6",
+  "version": "0.5.0-alpha.7",
   "name": "@briebug/ngrx-auto-entity",
   "description": "Automatic Entity State and Facades for NgRx. Simplifying reactive state!",
   "keywords": [

--- a/projects/ngrx-auto-entity/src/lib/actions/action-operators.ts
+++ b/projects/ngrx-auto-entity/src/lib/actions/action-operators.ts
@@ -41,7 +41,7 @@ export function ofEntityType<TModel, T extends EntityAction<TModel>>(
 }
 
 /**
- * Operator to filder many actions by entity type and entity action types.
+ * Operator to filter many actions by entity type and entity action types.
  *
  * @param actions$ The NgRx effects Actions stream
  * @param entity The entity types to filter for

--- a/projects/ngrx-auto-entity/src/lib/actions/actions.spec.ts
+++ b/projects/ngrx-auto-entity/src/lib/actions/actions.spec.ts
@@ -110,6 +110,8 @@ const testError = {
 };
 
 const criteria = { criteria: 'test' };
+const page = { page: 2, size: 10 };
+const range = { start: 10, end: 20 };
 
 const regex = {
   v4: /^(?:[a-f0-9]{8}-[a-f0-9]{4}-4[a-f0-9]{3}-[a-f0-9]{4}-[a-f0-9]{12})|(?:0{8}-0{4}-0{4}-0{4}-0{12})$/u,
@@ -197,7 +199,7 @@ describe('NgRX Auto-Entity: Actions', () => {
 
     describe('LoadFailure', () => {
       it('should construct EntityAction with proper details', () => {
-        const action = new LoadFailure(TestEntity, testError);
+        const action = new LoadFailure(TestEntity, testError, [1, 2], criteria);
 
         expect(action.type).toEqual('[TestEntity] (Generic) Load: Failure');
         expect(action.actionType).toEqual(EntityActionTypes.LoadFailure);
@@ -205,6 +207,8 @@ describe('NgRX Auto-Entity: Actions', () => {
         expect(action.info.modelName).toEqual('TestEntity');
 
         expect(action.error).toEqual(testError);
+        expect(action.keys).toEqual([1, 2]);
+        expect(action.criteria).toEqual(criteria);
       });
     });
   });
@@ -238,7 +242,7 @@ describe('NgRX Auto-Entity: Actions', () => {
 
     describe('LoadManyFailure', () => {
       it('should construct EntityAction with proper details', () => {
-        const action = new LoadManyFailure(TestEntity, testError);
+        const action = new LoadManyFailure(TestEntity, testError, criteria);
 
         expect(action.type).toEqual('[TestEntity] (Generic) Load Many: Failure');
         expect(action.actionType).toEqual(EntityActionTypes.LoadManyFailure);
@@ -246,6 +250,7 @@ describe('NgRX Auto-Entity: Actions', () => {
         expect(action.info.modelName).toEqual('TestEntity');
 
         expect(action.error).toEqual(testError);
+        expect(action.criteria).toEqual(criteria);
       });
     });
   });
@@ -279,7 +284,7 @@ describe('NgRX Auto-Entity: Actions', () => {
 
     describe('LoadAllFailure', () => {
       it('should construct EntityAction with proper details', () => {
-        const action = new LoadAllFailure(TestEntity, testError);
+        const action = new LoadAllFailure(TestEntity, testError, criteria);
 
         expect(action.type).toEqual('[TestEntity] (Generic) Load All: Failure');
         expect(action.actionType).toEqual(EntityActionTypes.LoadAllFailure);
@@ -287,6 +292,7 @@ describe('NgRX Auto-Entity: Actions', () => {
         expect(action.info.modelName).toEqual('TestEntity');
 
         expect(action.error).toEqual(testError);
+        expect(action.criteria).toEqual(criteria);
       });
     });
   });
@@ -342,7 +348,7 @@ describe('NgRX Auto-Entity: Actions', () => {
 
     describe('LoadPageFailure', () => {
       it('should construct EntityAction with proper details', () => {
-        const action = new LoadAllFailure(TestEntity, testError);
+        const action = new LoadAllFailure(TestEntity, testError, criteria);
 
         expect(action.type).toEqual('[TestEntity] (Generic) Load All: Failure');
         expect(action.actionType).toEqual(EntityActionTypes.LoadAllFailure);
@@ -350,6 +356,7 @@ describe('NgRX Auto-Entity: Actions', () => {
         expect(action.info.modelName).toEqual('TestEntity');
 
         expect(action.error).toEqual(testError);
+        expect(action.criteria).toEqual(criteria);
       });
     });
   });
@@ -454,7 +461,7 @@ describe('NgRX Auto-Entity: Actions', () => {
 
     describe('LoadRangeFailure', () => {
       it('should construct EntityAction with proper details', () => {
-        const action = new LoadRangeFailure(TestEntity, testError);
+        const action = new LoadRangeFailure(TestEntity, testError, range, criteria);
 
         expect(action.type).toEqual('[TestEntity] (Generic) Load Range: Failure');
         expect(action.actionType).toEqual(EntityActionTypes.LoadRangeFailure);
@@ -462,6 +469,8 @@ describe('NgRX Auto-Entity: Actions', () => {
         expect(action.info.modelName).toEqual('TestEntity');
 
         expect(action.error).toEqual(testError);
+        expect(action.range).toEqual(range);
+        expect(action.criteria).toEqual(criteria);
       });
     });
   });
@@ -507,7 +516,7 @@ describe('NgRX Auto-Entity: Actions', () => {
 
     describe('CreateFailure', () => {
       it('should construct EntityAction with proper details', () => {
-        const action = new CreateFailure(TestEntity, testError);
+        const action = new CreateFailure(TestEntity, testError, fyneman, criteria);
 
         expect(action.type).toEqual('[TestEntity] (Generic) Create: Failure');
         expect(action.actionType).toEqual(EntityActionTypes.CreateFailure);
@@ -515,6 +524,8 @@ describe('NgRX Auto-Entity: Actions', () => {
         expect(action.info.modelName).toEqual('TestEntity');
 
         expect(action.error).toEqual(testError);
+        expect(action.entity).toEqual(fyneman);
+        expect(action.criteria).toEqual(criteria);
       });
     });
   });
@@ -560,7 +571,7 @@ describe('NgRX Auto-Entity: Actions', () => {
 
     describe('CreateManyFailure', () => {
       it('should construct EntityAction with proper details', () => {
-        const action = new CreateManyFailure(TestEntity, testError);
+        const action = new CreateManyFailure(TestEntity, testError, scientists, criteria);
 
         expect(action.type).toEqual('[TestEntity] (Generic) Create Many: Failure');
         expect(action.actionType).toEqual(EntityActionTypes.CreateManyFailure);
@@ -568,6 +579,8 @@ describe('NgRX Auto-Entity: Actions', () => {
         expect(action.info.modelName).toEqual('TestEntity');
 
         expect(action.error).toEqual(testError);
+        expect(action.entities).toEqual(scientists);
+        expect(action.criteria).toEqual(criteria);
       });
     });
   });
@@ -613,7 +626,7 @@ describe('NgRX Auto-Entity: Actions', () => {
 
     describe('UpdateFailure', () => {
       it('should construct EntityAction with proper details', () => {
-        const action = new UpdateFailure(TestEntity, testError);
+        const action = new UpdateFailure(TestEntity, testError, fyneman, criteria);
 
         expect(action.type).toEqual('[TestEntity] (Generic) Update: Failure');
         expect(action.actionType).toEqual(EntityActionTypes.UpdateFailure);
@@ -621,6 +634,8 @@ describe('NgRX Auto-Entity: Actions', () => {
         expect(action.info.modelName).toEqual('TestEntity');
 
         expect(action.error).toEqual(testError);
+        expect(action.entity).toEqual(fyneman);
+        expect(action.criteria).toEqual(criteria);
       });
     });
   });
@@ -666,7 +681,7 @@ describe('NgRX Auto-Entity: Actions', () => {
 
     describe('UpdateManyFailure', () => {
       it('should construct EntityAction with proper details', () => {
-        const action = new UpdateManyFailure(TestEntity, testError);
+        const action = new UpdateManyFailure(TestEntity, testError, scientists, criteria);
 
         expect(action.type).toEqual('[TestEntity] (Generic) Update Many: Failure');
         expect(action.actionType).toEqual(EntityActionTypes.UpdateManyFailure);
@@ -674,6 +689,8 @@ describe('NgRX Auto-Entity: Actions', () => {
         expect(action.info.modelName).toEqual('TestEntity');
 
         expect(action.error).toEqual(testError);
+        expect(action.entities).toEqual(scientists);
+        expect(action.criteria).toEqual(criteria);
       });
     });
   });
@@ -719,7 +736,7 @@ describe('NgRX Auto-Entity: Actions', () => {
 
     describe('ReplaceFailure', () => {
       it('should construct EntityAction with proper details', () => {
-        const action = new ReplaceFailure(TestEntity, testError);
+        const action = new ReplaceFailure(TestEntity, testError, fyneman, criteria);
 
         expect(action.type).toEqual('[TestEntity] (Generic) Replace: Failure');
         expect(action.actionType).toEqual(EntityActionTypes.ReplaceFailure);
@@ -727,6 +744,8 @@ describe('NgRX Auto-Entity: Actions', () => {
         expect(action.info.modelName).toEqual('TestEntity');
 
         expect(action.error).toEqual(testError);
+        expect(action.entity).toEqual(fyneman);
+        expect(action.criteria).toEqual(criteria);
       });
     });
   });
@@ -772,7 +791,7 @@ describe('NgRX Auto-Entity: Actions', () => {
 
     describe('ReplaceManyFailure', () => {
       it('should construct EntityAction with proper details', () => {
-        const action = new ReplaceManyFailure(TestEntity, testError);
+        const action = new ReplaceManyFailure(TestEntity, testError, scientists, criteria);
 
         expect(action.type).toEqual('[TestEntity] (Generic) Replace Many: Failure');
         expect(action.actionType).toEqual(EntityActionTypes.ReplaceManyFailure);
@@ -780,6 +799,8 @@ describe('NgRX Auto-Entity: Actions', () => {
         expect(action.info.modelName).toEqual('TestEntity');
 
         expect(action.error).toEqual(testError);
+        expect(action.entities).toEqual(scientists);
+        expect(action.criteria).toEqual(criteria);
       });
     });
   });

--- a/projects/ngrx-auto-entity/src/lib/actions/actions.ts
+++ b/projects/ngrx-auto-entity/src/lib/actions/actions.ts
@@ -19,7 +19,13 @@ export class LoadSuccess<TModel> extends EntityAction<TModel> {
 }
 
 export class LoadFailure<TModel> extends EntityAction<TModel> {
-  constructor(type: new () => TModel, public error: any, correlationId?: string) {
+  constructor(
+    type: new () => TModel,
+    public error: any,
+    public keys: any,
+    public criteria: any,
+    correlationId?: string
+  ) {
     super(type, EntityActionTypes.LoadFailure, correlationId);
   }
 }
@@ -40,7 +46,7 @@ export class LoadManySuccess<TModel> extends EntityAction<TModel> {
 }
 
 export class LoadManyFailure<TModel> extends EntityAction<TModel> {
-  constructor(type: new () => TModel, public error: any, correlationId?: string) {
+  constructor(type: new () => TModel, public error: any, public criteria: any, correlationId?: string) {
     super(type, EntityActionTypes.LoadManyFailure, correlationId);
   }
 }
@@ -61,7 +67,7 @@ export class LoadAllSuccess<TModel> extends EntityAction<TModel> {
 }
 
 export class LoadAllFailure<TModel> extends EntityAction<TModel> {
-  constructor(type: new () => TModel, public error: any, correlationId?: string) {
+  constructor(type: new () => TModel, public error: any, public criteria: any, correlationId?: string) {
     super(type, EntityActionTypes.LoadAllFailure, correlationId);
   }
 }
@@ -82,7 +88,7 @@ export class LoadPageSuccess<TModel> extends EntityAction<TModel> {
 }
 
 export class LoadPageFailure<TModel> extends EntityAction<TModel> {
-  constructor(type: new () => TModel, public error: any, correlationId?: string) {
+  constructor(type: new () => TModel, public error: any, public page: Page, criteria: any, correlationId?: string) {
     super(type, EntityActionTypes.LoadPageFailure, correlationId);
   }
 }
@@ -103,7 +109,13 @@ export class LoadRangeSuccess<TModel> extends EntityAction<TModel> {
 }
 
 export class LoadRangeFailure<TModel> extends EntityAction<TModel> {
-  constructor(type: new () => TModel, public error: any, correlationId?: string) {
+  constructor(
+    type: new () => TModel,
+    public error: any,
+    public range: Range,
+    public criteria: any,
+    correlationId?: string
+  ) {
     super(type, EntityActionTypes.LoadRangeFailure, correlationId);
   }
 }
@@ -124,7 +136,13 @@ export class CreateSuccess<TModel> extends EntityAction<TModel> {
 }
 
 export class CreateFailure<TModel> extends EntityAction<TModel> {
-  constructor(type: new () => TModel, public error: any, correlationId?: string) {
+  constructor(
+    type: new () => TModel,
+    public error: any,
+    public entity: TModel,
+    public criteria: any,
+    correlationId?: string
+  ) {
     super(type, EntityActionTypes.CreateFailure, correlationId);
   }
 }
@@ -145,7 +163,13 @@ export class CreateManySuccess<TModel> extends EntityAction<TModel> {
 }
 
 export class CreateManyFailure<TModel> extends EntityAction<TModel> {
-  constructor(type: new () => TModel, public error: any, correlationId?: string) {
+  constructor(
+    type: new () => TModel,
+    public error: any,
+    public entities: TModel[],
+    public criteria: any,
+    correlationId?: string
+  ) {
     super(type, EntityActionTypes.CreateManyFailure, correlationId);
   }
 }
@@ -168,7 +192,13 @@ export class UpdateSuccess<TModel> extends EntityAction<TModel> {
 }
 
 export class UpdateFailure<TModel> extends EntityAction<TModel> {
-  constructor(type: new () => TModel, public error: any, correlationId?: string) {
+  constructor(
+    type: new () => TModel,
+    public error: any,
+    public entity: TModel,
+    public criteria: any,
+    correlationId?: string
+  ) {
     super(type, EntityActionTypes.UpdateFailure, correlationId);
   }
 }
@@ -191,7 +221,13 @@ export class UpdateManySuccess<TModel> extends EntityAction<TModel> {
 }
 
 export class UpdateManyFailure<TModel> extends EntityAction<TModel> {
-  constructor(type: new () => TModel, public error: any, correlationId?: string) {
+  constructor(
+    type: new () => TModel,
+    public error: any,
+    public entities: TModel[],
+    public criteria: any,
+    correlationId?: string
+  ) {
     super(type, EntityActionTypes.UpdateManyFailure, correlationId);
   }
 }
@@ -213,7 +249,13 @@ export class UpsertSuccess<TModel> extends EntityAction<TModel> {
 }
 
 export class UpsertFailure<TModel> extends EntityAction<TModel> {
-  constructor(type: new () => TModel, public error: any, correlationId?: string) {
+  constructor(
+    type: new () => TModel,
+    public error: any,
+    public entity: TModel,
+    public criteria: any,
+    correlationId?: string
+  ) {
     super(type, EntityActionTypes.UpsertFailure, correlationId);
   }
 }
@@ -235,7 +277,13 @@ export class UpsertManySuccess<TModel> extends EntityAction<TModel> {
 }
 
 export class UpsertManyFailure<TModel> extends EntityAction<TModel> {
-  constructor(type: new () => TModel, public error: any, correlationId?: string) {
+  constructor(
+    type: new () => TModel,
+    public error: any,
+    public entities: TModel[],
+    public criteria: any,
+    correlationId?: string
+  ) {
     super(type, EntityActionTypes.UpsertManyFailure, correlationId);
   }
 }
@@ -258,7 +306,13 @@ export class ReplaceSuccess<TModel> extends EntityAction<TModel> {
 }
 
 export class ReplaceFailure<TModel> extends EntityAction<TModel> {
-  constructor(type: new () => TModel, public error: any, correlationId?: string) {
+  constructor(
+    type: new () => TModel,
+    public error: any,
+    public entity: TModel,
+    public criteria: any,
+    correlationId?: string
+  ) {
     super(type, EntityActionTypes.ReplaceFailure, correlationId);
   }
 }
@@ -281,7 +335,13 @@ export class ReplaceManySuccess<TModel> extends EntityAction<TModel> {
 }
 
 export class ReplaceManyFailure<TModel> extends EntityAction<TModel> {
-  constructor(type: new () => TModel, public error: any, correlationId?: string) {
+  constructor(
+    type: new () => TModel,
+    public error: any,
+    public entities: TModel[],
+    public criteria: any,
+    correlationId?: string
+  ) {
     super(type, EntityActionTypes.ReplaceManyFailure, correlationId);
   }
 }
@@ -302,7 +362,13 @@ export class DeleteSuccess<TModel> extends EntityAction<TModel> {
 }
 
 export class DeleteFailure<TModel> extends EntityAction<TModel> {
-  constructor(type: new () => TModel, public error: any, correlationId?: string) {
+  constructor(
+    type: new () => TModel,
+    public error: any,
+    public entity: TModel,
+    public criteria: any,
+    correlationId?: string
+  ) {
     super(type, EntityActionTypes.DeleteFailure, correlationId);
   }
 }
@@ -323,7 +389,13 @@ export class DeleteManySuccess<TModel> extends EntityAction<TModel> {
 }
 
 export class DeleteManyFailure<TModel> extends EntityAction<TModel> {
-  constructor(type: new () => TModel, public error: any, correlationId?: string) {
+  constructor(
+    type: new () => TModel,
+    public error: any,
+    public entities: TModel[],
+    public criteria: any,
+    correlationId?: string
+  ) {
     super(type, EntityActionTypes.DeleteManyFailure, correlationId);
   }
 }
@@ -344,7 +416,13 @@ export class DeleteByKeySuccess<TModel> extends EntityAction<TModel> {
 }
 
 export class DeleteByKeyFailure<TModel> extends EntityAction<TModel> {
-  constructor(type: new () => TModel, public error: any, correlationId?: string) {
+  constructor(
+    type: new () => TModel,
+    public error: any,
+    public key: EntityIdentity,
+    public criteria: any,
+    correlationId?: string
+  ) {
     super(type, EntityActionTypes.DeleteByKeyFailure, correlationId);
   }
 }
@@ -365,7 +443,13 @@ export class DeleteManyByKeysSuccess<TModel> extends EntityAction<TModel> {
 }
 
 export class DeleteManyByKeysFailure<TModel> extends EntityAction<TModel> {
-  constructor(type: new () => TModel, public error: any, correlationId?: string) {
+  constructor(
+    type: new () => TModel,
+    public error: any,
+    public keys: EntityIdentity[],
+    public criteria: any,
+    correlationId?: string
+  ) {
     super(type, EntityActionTypes.DeleteManyByKeysFailure, correlationId);
   }
 }

--- a/projects/ngrx-auto-entity/src/lib/actions/entity-action.ts
+++ b/projects/ngrx-auto-entity/src/lib/actions/entity-action.ts
@@ -1,6 +1,7 @@
 import { Action } from '@ngrx/store';
 
 import { uuid } from '../../util/uuid';
+import { EntityActionTypes } from './action-types';
 import { IEntityInfo } from './entity-info';
 import { TNew } from './model-constructor';
 import { setInfo, setType } from './util';
@@ -10,7 +11,7 @@ export interface ICorrelatedAction {
 }
 
 export interface IEntityAction extends Action, ICorrelatedAction {
-  actionType: string;
+  actionType: EntityActionTypes;
   info: IEntityInfo;
 }
 
@@ -21,7 +22,11 @@ export abstract class EntityAction<TModel> implements IEntityAction {
   type: string;
   info: IEntityInfo;
 
-  protected constructor(type: TNew<TModel>, public actionType: string, public correlationId: string = uuid()) {
+  protected constructor(
+    type: TNew<TModel>,
+    public actionType: EntityActionTypes,
+    public correlationId: string = uuid()
+  ) {
     this.info = setInfo(type);
     this.type = setType(this.actionType, this.info);
   }

--- a/projects/ngrx-auto-entity/src/lib/actions/entity-info.ts
+++ b/projects/ngrx-auto-entity/src/lib/actions/entity-info.ts
@@ -1,12 +1,9 @@
-import { IEntityTransformer } from '../decorators/entity';
+import { IEntityNames, IEntityTransformer } from '../decorators/entity';
 
 /**
  * Descriptor of an Entity model and related metadata.
  */
-export interface IEntityInfo {
-  modelName: string;
-  pluralName?: string;
-  uriName?: string;
+export interface IEntityInfo extends IEntityNames {
   modelType: new () => any;
   transform?: IEntityTransformer[];
 }

--- a/projects/ngrx-auto-entity/src/lib/decorators/entity.ts
+++ b/projects/ngrx-auto-entity/src/lib/decorators/entity.ts
@@ -12,20 +12,23 @@ export interface IEffectExcept {
 /**
  * Defines an entity data transformer capable of transforming data to and from the server.
  */
-export interface IEntityTransformer {
-  fromServer?: (data: any, criteria?: any) => any;
-  toServer?: (entity: any, criteria?: any) => any;
+export interface IEntityTransformer<T = any, U = any, V = any> {
+  fromServer?: (data: U, criteria?: any) => T;
+  toServer?: (entity: T, criteria?: any) => V;
+}
+
+export interface IEntityNames {
+  modelName: string;
+  pluralName?: string;
+  uriName?: string;
 }
 
 /**
  * The options that may be configured for a decorated entity model.
  */
-export interface IEntityOptions {
-  modelName: string;
-  uriName?: string;
-  pluralName?: string;
-  comparer?: (a, b) => number;
-  transform?: IEntityTransformer[];
+export interface IEntityOptions<T = any> extends IEntityNames {
+  comparer?: (a: T, b: T) => number;
+  transform?: Array<IEntityTransformer<T>>;
   excludeEffects?: IEffectExclusions | IEffectExcept;
 }
 

--- a/projects/ngrx-auto-entity/src/lib/effects/operators.ts
+++ b/projects/ngrx-auto-entity/src/lib/effects/operators.ts
@@ -123,24 +123,10 @@ export class EntityOperators {
           return this.entityService.load(info, keys, criteria).pipe(
             map((ref: IEntityRef<TModel>) => new LoadSuccess<TModel>(ref.info.modelType, ref.entity, correlationId)),
             catchError((error: IEntityError<TModel>) =>
-              handleError(error, new LoadFailure<TModel>(error.info.modelType, error.err, correlationId))
-            )
-          );
-        })
-      );
-  }
-
-  loadAll<TModel>() {
-    return (source: Observable<LoadAll<TModel>>) =>
-      source.pipe(
-        shouldApplyEffect(),
-        mergeMap(({ info, criteria, correlationId }) => {
-          return this.entityService.loadAll(info, criteria).pipe(
-            map(
-              (ref: IEntityRef<TModel[]>) => new LoadAllSuccess<TModel>(ref.info.modelType, ref.entity, correlationId)
-            ),
-            catchError((error: IEntityError<TModel>) =>
-              handleError(error, new LoadAllFailure<TModel>(error.info.modelType, error.err, correlationId))
+              handleError(
+                error,
+                new LoadFailure<TModel>(error.info.modelType, error.err, keys, criteria, correlationId)
+              )
             )
           );
         })
@@ -157,7 +143,24 @@ export class EntityOperators {
               (ref: IEntityRef<TModel[]>) => new LoadManySuccess<TModel>(ref.info.modelType, ref.entity, correlationId)
             ),
             catchError((error: IEntityError<TModel>) =>
-              handleError(error, new LoadManyFailure<TModel>(error.info.modelType, error.err, correlationId))
+              handleError(error, new LoadManyFailure<TModel>(error.info.modelType, error.err, criteria, correlationId))
+            )
+          );
+        })
+      );
+  }
+
+  loadAll<TModel>() {
+    return (source: Observable<LoadAll<TModel>>) =>
+      source.pipe(
+        shouldApplyEffect(),
+        mergeMap(({ info, criteria, correlationId }) => {
+          return this.entityService.loadAll(info, criteria).pipe(
+            map(
+              (ref: IEntityRef<TModel[]>) => new LoadAllSuccess<TModel>(ref.info.modelType, ref.entity, correlationId)
+            ),
+            catchError((error: IEntityError<TModel>) =>
+              handleError(error, new LoadAllFailure<TModel>(error.info.modelType, error.err, criteria, correlationId))
             )
           );
         })
@@ -175,7 +178,10 @@ export class EntityOperators {
                 new LoadPageSuccess<TModel>(ref.info.modelType, ref.entity, ref.pageInfo, correlationId)
             ),
             catchError((error: IEntityError<TModel>) =>
-              handleError(error, new LoadPageFailure<TModel>(error.info.modelType, error.err, correlationId))
+              handleError(
+                error,
+                new LoadPageFailure<TModel>(error.info.modelType, error.err, page, criteria, correlationId)
+              )
             )
           );
         })
@@ -193,7 +199,10 @@ export class EntityOperators {
                 new LoadRangeSuccess<TModel>(ref.info.modelType, ref.entity, ref.rangeInfo, correlationId)
             ),
             catchError((error: IEntityError<TModel>) =>
-              handleError(error, new LoadRangeFailure<TModel>(error.info.modelType, error.err, correlationId))
+              handleError(
+                error,
+                new LoadRangeFailure<TModel>(error.info.modelType, error.err, range, criteria, correlationId)
+              )
             )
           );
         })
@@ -208,7 +217,10 @@ export class EntityOperators {
           return this.entityService.create<TModel>(info, entity, criteria).pipe(
             map((ref: IEntityRef<TModel>) => new CreateSuccess<TModel>(ref.info.modelType, ref.entity, correlationId)),
             catchError((error: IEntityError<TModel>) =>
-              handleError(error, new CreateFailure<TModel>(error.info.modelType, error.err, correlationId))
+              handleError(
+                error,
+                new CreateFailure<TModel>(error.info.modelType, error.err, entity, criteria, correlationId)
+              )
             )
           );
         })
@@ -226,7 +238,10 @@ export class EntityOperators {
                 new CreateManySuccess<TModel>(ref.info.modelType, ref.entity, correlationId)
             ),
             catchError((error: IEntityError<TModel>) =>
-              handleError(error, new CreateManyFailure<TModel>(error.info.modelType, error.err, correlationId))
+              handleError(
+                error,
+                new CreateManyFailure<TModel>(error.info.modelType, error.err, entities, criteria, correlationId)
+              )
             )
           );
         })
@@ -241,7 +256,10 @@ export class EntityOperators {
           return this.entityService.update<TModel>(info, entity, criteria).pipe(
             map((ref: IEntityRef<TModel>) => new UpdateSuccess<TModel>(ref.info.modelType, ref.entity, correlationId)),
             catchError((error: IEntityError<TModel>) =>
-              handleError(error, new UpdateFailure<TModel>(error.info.modelType, error.err, correlationId))
+              handleError(
+                error,
+                new UpdateFailure<TModel>(error.info.modelType, error.err, entity, criteria, correlationId)
+              )
             )
           );
         })
@@ -259,7 +277,10 @@ export class EntityOperators {
                 new UpdateManySuccess<TModel>(ref.info.modelType, ref.entity, correlationId)
             ),
             catchError((error: IEntityError<TModel>) =>
-              handleError(error, new UpdateManyFailure<TModel>(error.info.modelType, error.err, correlationId))
+              handleError(
+                error,
+                new UpdateManyFailure<TModel>(error.info.modelType, error.err, entities, criteria, correlationId)
+              )
             )
           );
         })
@@ -274,7 +295,10 @@ export class EntityOperators {
           return this.entityService.upsert<TModel>(info, entity, criteria).pipe(
             map((ref: IEntityRef<TModel>) => new UpsertSuccess<TModel>(ref.info.modelType, ref.entity, correlationId)),
             catchError((error: IEntityError<TModel>) =>
-              handleError(error, new UpsertFailure<TModel>(error.info.modelType, error.err, correlationId))
+              handleError(
+                error,
+                new UpsertFailure<TModel>(error.info.modelType, error.err, entity, criteria, correlationId)
+              )
             )
           );
         })
@@ -292,7 +316,10 @@ export class EntityOperators {
                 new UpsertManySuccess<TModel>(ref.info.modelType, ref.entity, correlationId)
             ),
             catchError((error: IEntityError<TModel>) =>
-              handleError(error, new UpsertManyFailure<TModel>(error.info.modelType, error.err, correlationId))
+              handleError(
+                error,
+                new UpsertManyFailure<TModel>(error.info.modelType, error.err, entities, criteria, correlationId)
+              )
             )
           );
         })
@@ -307,7 +334,10 @@ export class EntityOperators {
           return this.entityService.replace<TModel>(info, entity, criteria).pipe(
             map((ref: IEntityRef<TModel>) => new ReplaceSuccess<TModel>(ref.info.modelType, ref.entity, correlationId)),
             catchError((error: IEntityError<TModel>) =>
-              handleError(error, new ReplaceFailure<TModel>(error.info.modelType, error.err, correlationId))
+              handleError(
+                error,
+                new ReplaceFailure<TModel>(error.info.modelType, error.err, entity, criteria, correlationId)
+              )
             )
           );
         })
@@ -325,7 +355,10 @@ export class EntityOperators {
                 new ReplaceManySuccess<TModel>(ref.info.modelType, ref.entity, correlationId)
             ),
             catchError((error: IEntityError<TModel>) =>
-              handleError(error, new ReplaceManyFailure<TModel>(error.info.modelType, error.err, correlationId))
+              handleError(
+                error,
+                new ReplaceManyFailure<TModel>(error.info.modelType, error.err, entities, criteria, correlationId)
+              )
             )
           );
         })
@@ -340,7 +373,10 @@ export class EntityOperators {
           return this.entityService.delete(info, entity, criteria).pipe(
             map((ref: IEntityRef<TModel>) => new DeleteSuccess<TModel>(ref.info.modelType, ref.entity, correlationId)),
             catchError((error: IEntityError<TModel>) =>
-              handleError(error, new DeleteFailure<TModel>(error.info.modelType, error.err, correlationId))
+              handleError(
+                error,
+                new DeleteFailure<TModel>(error.info.modelType, error.err, entity, criteria, correlationId)
+              )
             )
           );
         })
@@ -358,7 +394,10 @@ export class EntityOperators {
                 new DeleteManySuccess<TModel>(ref.info.modelType, ref.entity, correlationId)
             ),
             catchError((error: IEntityError<TModel>) =>
-              handleError(error, new DeleteManyFailure<TModel>(error.info.modelType, error.err, correlationId))
+              handleError(
+                error,
+                new DeleteManyFailure<TModel>(error.info.modelType, error.err, entities, criteria, correlationId)
+              )
             )
           );
         })
@@ -376,7 +415,10 @@ export class EntityOperators {
                 new DeleteByKeySuccess<TModel>(ref.info.modelType, ref.entityIdentity, correlationId)
             ),
             catchError((error: IEntityError<TModel>) =>
-              handleError(error, new DeleteByKeyFailure<TModel>(error.info.modelType, error.err, correlationId))
+              handleError(
+                error,
+                new DeleteByKeyFailure<TModel>(error.info.modelType, error.err, key, criteria, correlationId)
+              )
             )
           );
         })
@@ -394,7 +436,10 @@ export class EntityOperators {
                 new DeleteManyByKeysSuccess<TModel>(ref.info.modelType, ref.entityIdentities, correlationId)
             ),
             catchError((error: IEntityError<TModel>) =>
-              handleError(error, new DeleteManyByKeysFailure<TModel>(error.info.modelType, error.err, correlationId))
+              handleError(
+                error,
+                new DeleteManyByKeysFailure<TModel>(error.info.modelType, error.err, keys, criteria, correlationId)
+              )
             )
           );
         })


### PR DESCRIPTION
- provide entity/entities to *failure actions
- provide key(s) to DeleteByKeys and DeleteManyByKeys
- update specs
- typing refactors and improvements
- narrows type on reducer from string to `EntityActionTypes`, fix lint error in reducer
- bump lib version

fixes #115 