### PR TITLE
fix/revert entity typing

### DIFF
--- a/projects/ngrx-auto-entity/package.json
+++ b/projects/ngrx-auto-entity/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.5.0-alpha.7",
+  "version": "0.5.0-alpha.8",
   "name": "@briebug/ngrx-auto-entity",
   "description": "Automatic Entity State and Facades for NgRx. Simplifying reactive state!",
   "keywords": [

--- a/projects/ngrx-auto-entity/src/lib/decorators/entity-util.ts
+++ b/projects/ngrx-auto-entity/src/lib/decorators/entity-util.ts
@@ -28,7 +28,7 @@ export const entityComparer = <TModel>(entityOrType: TNew<TModel> | TModel): Ent
 
 export const entityTransforms = <TModel>(
   entityOrType: TNew<TModel> | TModel
-): Array<IEntityTransformer<TModel>> | null | undefined =>
+): IEntityTransformer[] | null | undefined =>
   entityOrType &&
   ((entityOrType[ENTITY_OPTS_PROP] ||
     (entityOrType.constructor ? entityOrType.constructor[ENTITY_OPTS_PROP] : {}) ||

--- a/projects/ngrx-auto-entity/src/lib/decorators/entity.ts
+++ b/projects/ngrx-auto-entity/src/lib/decorators/entity.ts
@@ -12,12 +12,12 @@ export interface IEffectExcept {
 /**
  * Defines an entity data transformer capable of transforming data to and from the server.
  */
-export interface IEntityTransformer<T = any, U = any, V = any> {
-  fromServer?: (data: U, criteria?: any) => T;
-  toServer?: (entity: T, criteria?: any) => V;
+export interface IEntityTransformer {
+  fromServer?: (data: any, criteria?: any) => any;
+  toServer?: (entity: any, criteria?: any) => any;
 }
 
-export type EntityComparer = <T = any>(a: T, b: T) => number;
+export type EntityComparer = (a, b) => number;
 
 export interface IEntityNames {
   modelName: string;
@@ -28,9 +28,9 @@ export interface IEntityNames {
 /**
  * The options that may be configured for a decorated entity model.
  */
-export interface IEntityOptions<T = any> extends IEntityNames {
+export interface IEntityOptions extends IEntityNames {
   comparer?: EntityComparer;
-  transform?: Array<IEntityTransformer<T>>;
+  transform?: IEntityTransformer[];
   excludeEffects?: IEffectExclusions | IEffectExcept;
 }
 


### PR DESCRIPTION
Revert the generic typing for Entity info which forces Entities to be typed. This should revert the typing while maintaining the shared `IEntityNames` interface.