### PR TITLE
fix: deselectAll error

### DIFF
--- a/projects/ngrx-auto-entity/src/lib/actions/actions.spec.ts
+++ b/projects/ngrx-auto-entity/src/lib/actions/actions.spec.ts
@@ -1125,6 +1125,17 @@ describe('NgRX Auto-Entity: Actions', () => {
       expect(action.entities).toEqual(scientists);
     });
 
+    it('should construct EntityAction if null is passed', () => {
+      const action = new DeselectedMany(TestEntity, null);
+
+      expect(action.type).toEqual('[TestEntity] (Generic) Deselection of Many');
+      expect(action.actionType).toEqual(EntityActionTypes.DeselectedMany);
+      expect(action.info.modelType).toEqual(TestEntity);
+      expect(action.info.modelName).toEqual('TestEntity');
+
+      expect(action.entities).toEqual(null);
+    });
+
     it('should throw error during construction if non-array (object) passed', () => {
       expect(() => {
         // tslint:disable-next-line:no-unused-expression
@@ -1132,10 +1143,10 @@ describe('NgRX Auto-Entity: Actions', () => {
       }).toThrow(new Error('[NGRX-AE] ! DeselectedMany action requires an array of entities or keys.'));
     });
 
-    it('should throw error during construction if non-array (null) passed', () => {
+    it('should throw error during construction if non-array (number) passed', () => {
       expect(() => {
         // tslint:disable-next-line:no-unused-expression
-        new DeselectedMany(TestEntity, null);
+        new DeselectedMany(TestEntity, 2 as any);
       }).toThrow(new Error('[NGRX-AE] ! DeselectedMany action requires an array of entities or keys.'));
     });
 

--- a/projects/ngrx-auto-entity/src/lib/actions/deselection-actions.ts
+++ b/projects/ngrx-auto-entity/src/lib/actions/deselection-actions.ts
@@ -59,10 +59,10 @@ export class Deselected<TModel> extends EntityAction<TModel> {
  * Indicates the de-selection of many entities in the store
  */
 export class DeselectedMany<TModel> extends EntityAction<TModel> {
-  constructor(type: new () => TModel, public entities: Array<TModel | EntityIdentity>, correlationId?: string) {
+  constructor(type: new () => TModel, public entities: Array<TModel | EntityIdentity> | null, correlationId?: string) {
     super(type, EntityActionTypes.DeselectedMany, correlationId);
 
-    if (!Array.isArray(entities)) {
+    if (!Array.isArray(entities) && entities !== null) {
       throw new Error('[NGRX-AE] ! DeselectedMany action requires an array of entities or keys.');
     }
   }


### PR DESCRIPTION
**Problem**: after `deselectAll`, then it dispatches `DeselectedMany` with `null` entities (https://github.com/briebug/ngrx-auto-entity/blob/2b130c3e9d4939dbe5c5bf6266ac560495f1ca9c/projects/ngrx-auto-entity/src/lib/effects/operators.ts#L405), but DeselectedMany required an array for entities

**Solution**: allow `null`

Resolves #174