### PR TITLE
fix: reverse order of transforms to server

### DIFF
--- a/projects/ngrx-auto-entity/src/lib/effects/if-necessary-operator-utils.spec.ts
+++ b/projects/ngrx-auto-entity/src/lib/effects/if-necessary-operator-utils.spec.ts
@@ -294,14 +294,25 @@ describe('warnIfMissingStore()', () => {
     try {
       const now = Date.now();
       const nowSpy = jest.spyOn(Date, 'now').mockReturnValue(now);
+      console.log('now', new Date(now));
       const warnSpy = jest.spyOn(console, 'warn');
       warnIfMissingStore();
       warnIfMissingStore();
       const now2 = new Date(now);
-      nowSpy.mockReturnValue(new Date(now2.getHours(), now2.getMinutes(), now2.getSeconds() + 5).valueOf());
+      console.log('now2', now2);
+      nowSpy.mockReturnValue(
+        new Date(now2.getFullYear(), now2.getMonth(), now2.getDate(), now2.getHours(), now2.getMinutes(), now2.getSeconds() + 5).valueOf()
+      );
+      const now2a = new Date(Date.now());
+      console.log('now2a', now2a);
       warnIfMissingStore();
       const now3 = new Date(now);
-      nowSpy.mockReturnValue(new Date(now3.getHours(), now3.getMinutes(), now3.getSeconds() + 16).valueOf());
+      console.log('now3', now3);
+      nowSpy.mockReturnValue(
+        new Date(now3.getFullYear(), now3.getMonth(), now3.getDate(), now3.getHours(), now3.getMinutes(), now3.getSeconds() + 16).valueOf()
+      );
+      const now3a = new Date(Date.now());
+      console.log('now3a', now3a);
       warnIfMissingStore();
       expect(warnSpy).toHaveBeenCalledTimes(2);
     } finally {

--- a/projects/ngrx-auto-entity/src/lib/effects/if-necessary-operator-utils.ts
+++ b/projects/ngrx-auto-entity/src/lib/effects/if-necessary-operator-utils.ts
@@ -43,7 +43,7 @@ export const nowAfterExpiry = (expiry: Date): boolean => expiry < new Date();
 export const isSubsequentRange = (a: any, b: any) => (a.start || a.first || a.skip + a.take) > (b.end || b.last || b.skip + b.take);
 
 export const warnIfMissingStore: (() => void) & { lastWarnTime?: number } = () =>
-  !warnIfMissingStore.lastWarnTime || new Date(warnIfMissingStore.lastWarnTime).getSeconds() - new Date(Date.now()).getSeconds() > 15
+  !warnIfMissingStore.lastWarnTime || Math.abs(new Date(warnIfMissingStore.lastWarnTime).valueOf() - new Date(Date.now()).valueOf()) > 15000
     ? (console.warn(
         // tslint:disable-next-line:max-line-length
         '[NGRX-AE] Warning! The NGRX_AUTO_ENTITY_APP_STORE provider has not been configured! *IfNecessary actions require accessing your store in order to function properly!'

--- a/projects/ngrx-auto-entity/src/lib/service/transformation.ts
+++ b/projects/ngrx-auto-entity/src/lib/service/transformation.ts
@@ -26,12 +26,12 @@ export const transformArrayFromServer = <TModel>(entityInfo: IEntityInfo, criter
 };
 
 export const transformSingleToServer = <TModel>(entityInfo: IEntityInfo, criteria?: any) => (originalEntity: TModel): any => {
-  const transforms = getTransforms(entityInfo.transform, TO);
+  const transforms = getTransforms(entityInfo.transform, TO).reverse();
   return applyTransforms(transforms, criteria)(originalEntity);
 };
 
 export const transformArrayToServer = <TModel>(entityInfo: IEntityInfo, criteria?: any) => (entities: TModel[]): any[] => {
-  const transforms = getTransforms(entityInfo.transform, TO);
+  const transforms = getTransforms(entityInfo.transform, TO).reverse();
   return entities.map(applyTransforms(transforms, criteria));
 };
 


### PR DESCRIPTION
Reverses the order of transforms when going to server for both a single entity or multiple entities.

Resolves #179