### PR TITLE
feat: add selectors for tracking if loads were attempted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,24 @@
+<a name="0.8.1"></a>
+
+# [0.8.1](https://github.com/briebug/ngrx-auto-entity/compare/0.8.1-beta.1...0.8.1) Beta (2022-05-05)
+
+Added two new loading related selectors: hasBeenLoaded and loadWasAttempted. These selectors allow
+end developers to determine if a load has ever been attempted before, which is sometimes necessary
+to display the correct information in a UI component. Until a load has at least been attempted, it 
+would generally be inappropriate to display to the user that there are no Entities X, however as
+the current state of each entity currently stands, there is no way to determine that particular 
+state of an entity. You can determine if an entity is loading or not, which is useful for displaying
+a spinner, but other messaging requires more information.
+
+### Features
+
+- **selectors:** Added selectHasBeenLoaded to selector map
+- **selectors:** Added selectLoadWasAttempted to selector map
+
+
 <a name="0.8.0-beta.1"></a>
 
-# [0.7.2](https://github.com/briebug/ngrx-auto-entity/compare/0.7.2...0.8.1-beta.1) Beta (2022-04-05)
+# [0.8.0-beta.1](https://github.com/briebug/ngrx-auto-entity/compare/0.7.2...0.8.1-beta.1) Beta (2022-04-05)
 
 Updated state builders to build all state functionality "on-demand" to limit memory footprint when
 lots of entities are used. This aligns selectors, facades, etc. with the way actions were implemented

--- a/projects/ngrx-auto-entity/package.json
+++ b/projects/ngrx-auto-entity/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.8.0-beta.1",
+  "version": "0.8.1",
   "name": "@briebug/ngrx-auto-entity",
   "description": "Automatic Entity State and Facades for NgRx. Simplifying reactive state!",
   "license": "SEE LICENSE IN LICENSE.md",

--- a/projects/ngrx-auto-entity/src/lib/selectors/tracking.selectors.ts
+++ b/projects/ngrx-auto-entity/src/lib/selectors/tracking.selectors.ts
@@ -1,6 +1,16 @@
 import { IEntityTracking } from '../util/entity-state';
 
 // prettier-ignore
+export const mapToHasBeenLoaded =
+  (tracking: IEntityTracking): boolean =>
+    tracking?.loadedAt != null;
+
+// prettier-ignore
+export const mapToLoadWasAttempted =
+  (tracking: IEntityTracking): boolean =>
+    tracking?.isLoading != null;
+
+// prettier-ignore
 export const mapToIsLoading =
   (tracking: IEntityTracking): boolean =>
     !tracking ? false : !!tracking.isLoading;

--- a/projects/ngrx-auto-entity/src/lib/util/facade-builder.ts
+++ b/projects/ngrx-auto-entity/src/lib/util/facade-builder.ts
@@ -52,6 +52,8 @@ export const buildFacade = <TModel, TParentState>(selectors: ISelectorMap<TParen
       this.currentPage$ = this.store.select(selectors.selectCurrentPage);
       this.currentRange$ = this.store.select(selectors.selectCurrentRange);
       this.totalPageable$ = this.store.select(selectors.selectTotalPageable);
+      this.hasBeenLoaded$ = this.store.select(selectors.selectHasBeenLoaded);
+      this.loadWasAttempted$ = this.store.select(selectors.selectLoadWasAttempted);
       this.isLoading$ = this.store.select(selectors.selectIsLoading);
       this.isSaving$ = this.store.select(selectors.selectIsSaving);
       this.isDeleting$ = this.store.select(selectors.selectIsDeleting);
@@ -80,6 +82,8 @@ export const buildFacade = <TModel, TParentState>(selectors: ISelectorMap<TParen
     currentPage$: Observable<Page>;
     currentRange$: Observable<Range>;
     totalPageable$: Observable<number>;
+    hasBeenLoaded$: Observable<boolean>;
+    loadWasAttempted$: Observable<boolean>;
     isLoading$: Observable<boolean>;
     isSaving$: Observable<boolean>;
     isDeleting$: Observable<boolean>;

--- a/projects/ngrx-auto-entity/src/lib/util/facade.ts
+++ b/projects/ngrx-auto-entity/src/lib/util/facade.ts
@@ -24,6 +24,8 @@ export interface IEntityFacade<TModel> {
   currentPage$: Observable<Page>;
   currentRange$: Observable<Range>;
   totalPageable$: Observable<number>;
+  hasBeenLoaded$: Observable<boolean>;
+  loadWasAttempted$: Observable<boolean>;
   isLoading$: Observable<boolean>;
   isSaving$: Observable<boolean>;
   isDeleting$: Observable<boolean>;

--- a/projects/ngrx-auto-entity/src/lib/util/selector-map-builder.spec.ts
+++ b/projects/ngrx-auto-entity/src/lib/util/selector-map-builder.spec.ts
@@ -54,6 +54,8 @@ const selectorProperties = [
   'selectCurrentPage',
   'selectCurrentRange',
   'selectTotalPageable',
+  'selectHasBeenLoaded',
+  'selectLoadWasAttempted',
   'selectIsLoading',
   'selectIsSaving',
   'selectIsDeleting',
@@ -422,6 +424,78 @@ describe('buildSelectorMap()', () => {
       const { selectHasNoEntities } = buildSelectorMap<ITestState, IEntityState<Test>, Test, unknown>(getState);
       const entities = store.select(selectHasNoEntities);
       expect(entities).toBeObservable(hot('a', { a: false }));
+    });
+  });
+
+  describe('selectHasBeenLoaded', () => {
+    it('should return true if the loadedAt date is non-nullish', () => {
+      const store: MockStore<{}> = TestBed.inject(MockStore);
+
+      store.resetSelectors();
+      store.setState({
+        test: {
+          tracking: {
+            loadedAt: Date.now()
+          }
+        }
+      });
+
+      const getState = state => state.test;
+
+      const { selectHasBeenLoaded } = buildSelectorMap<ITestState, IEntityState<Test>, Test, unknown>(getState);
+      const hasBeen = store.select(selectHasBeenLoaded);
+      expect(hasBeen).toBeObservable(hot('a', { a: true }));
+    });
+
+    it('should return false if the loadedAt date is nullish', () => {
+      const store: MockStore<{}> = TestBed.inject(MockStore);
+
+      store.resetSelectors();
+      store.setState({
+        test: {}
+      });
+
+      const getState = state => state.test;
+
+      const { selectHasBeenLoaded } = buildSelectorMap<ITestState, IEntityState<Test>, Test, unknown>(getState);
+      const hasBeen = store.select(selectHasBeenLoaded);
+      expect(hasBeen).toBeObservable(hot('a', { a: false }));
+    });
+  });
+
+  describe('selectLoadWasAttempted', () => {
+    it('should return true if the isLoading tracking flag is non-nullish', () => {
+      const store: MockStore<{}> = TestBed.inject(MockStore);
+
+      store.resetSelectors();
+      store.setState({
+        test: {
+          tracking: {
+            isLoading: false
+          }
+        }
+      });
+
+      const getState = state => state.test;
+
+      const { selectLoadWasAttempted } = buildSelectorMap<ITestState, IEntityState<Test>, Test, unknown>(getState);
+      const hasBeen = store.select(selectLoadWasAttempted);
+      expect(hasBeen).toBeObservable(hot('a', { a: true }));
+    });
+
+    it('should return false if the isLoading tracking flag is nullish', () => {
+      const store: MockStore<{}> = TestBed.inject(MockStore);
+
+      store.resetSelectors();
+      store.setState({
+        test: {}
+      });
+
+      const getState = state => state.test;
+
+      const { selectLoadWasAttempted } = buildSelectorMap<ITestState, IEntityState<Test>, Test, unknown>(getState);
+      const hasBeen = store.select(selectLoadWasAttempted);
+      expect(hasBeen).toBeObservable(hot('a', { a: false }));
     });
   });
 });

--- a/projects/ngrx-auto-entity/src/lib/util/selector-map-builder.ts
+++ b/projects/ngrx-auto-entity/src/lib/util/selector-map-builder.ts
@@ -19,10 +19,12 @@ import {
 import {
   mapToCreatedAt,
   mapToDeletedAt,
+  mapToHasBeenLoaded,
   mapToIsDeleting,
   mapToIsLoading,
   mapToIsSaving,
   mapToLoadedAt,
+  mapToLoadWasAttempted,
   mapToReplacedAt,
   mapToSavedAt,
   mapToUpdatedAt
@@ -133,6 +135,14 @@ export const buildSelectorMap = <TParentState, TState extends IEntityState<TMode
     }
 
     // Tracking:
+    get selectHasBeenLoaded() {
+      return createSelector(this.selectTracking, mapToHasBeenLoaded);
+    }
+
+    get selectLoadWasAttempted() {
+      return createSelector(this.selectTracking, mapToLoadWasAttempted);
+    }
+
     get selectIsLoading() {
       return createSelector(this.selectTracking, mapToIsLoading);
     }

--- a/projects/ngrx-auto-entity/src/lib/util/selector-map.ts
+++ b/projects/ngrx-auto-entity/src/lib/util/selector-map.ts
@@ -29,6 +29,8 @@ export interface ISelectorMap<TParentState, TModel> {
   selectCurrentPage: MemoizedSelector<object | TParentState, Page | undefined>;
   selectCurrentRange: MemoizedSelector<object | TParentState, Range | undefined>;
   selectTotalPageable: MemoizedSelector<object | TParentState, number>;
+  selectHasBeenLoaded: MemoizedSelector<object | TParentState, boolean>;
+  selectLoadWasAttempted: MemoizedSelector<object | TParentState, boolean>;
   selectIsLoading: MemoizedSelector<object | TParentState, boolean>;
   selectIsSaving: MemoizedSelector<object | TParentState, boolean>;
   selectIsDeleting: MemoizedSelector<object | TParentState, boolean>;

--- a/projects/ngrx-auto-entity/src/lib/util/state-builder.spec.ts
+++ b/projects/ngrx-auto-entity/src/lib/util/state-builder.spec.ts
@@ -60,6 +60,8 @@ describe('buildState()', () => {
     expect(built.selectors).toSatisfy(selectors => selectors.__proto__.hasOwnProperty('selectCurrentPage'));
     expect(built.selectors).toSatisfy(selectors => selectors.__proto__.hasOwnProperty('selectCurrentRange'));
     expect(built.selectors).toSatisfy(selectors => selectors.__proto__.hasOwnProperty('selectTotalPageable'));
+    expect(built.selectors).toSatisfy(selectors => selectors.__proto__.hasOwnProperty('selectHasBeenLoaded'));
+    expect(built.selectors).toSatisfy(selectors => selectors.__proto__.hasOwnProperty('selectLoadWasAttempted'));
     expect(built.selectors).toSatisfy(selectors => selectors.__proto__.hasOwnProperty('selectIsLoading'));
     expect(built.selectors).toSatisfy(selectors => selectors.__proto__.hasOwnProperty('selectIsSaving'));
     expect(built.selectors).toSatisfy(selectors => selectors.__proto__.hasOwnProperty('selectIsDeleting'));
@@ -142,6 +144,8 @@ describe('buildState()', () => {
           selectHasNoEntities: hasNoTestEntities,
           selectIsDeleting: testIsDeleting,
           selectIsDirty: testIsDirty,
+          selectHasBeenLoaded: testHasBeenLoaded,
+          selectLoadWasAttempted: testLoadWasAttempted,
           selectIsLoading: testIsLoading,
           selectIsSaving: testIsSaving,
           selectLoadedAt: testLoadedAt,
@@ -176,6 +180,8 @@ describe('buildState()', () => {
           selectHasNoEntities: hasNoTest2Entities,
           selectIsDeleting: test2IsDeleting,
           selectIsDirty: test2IsDirty,
+          selectHasBeenLoaded: test2HasBeenLoaded,
+          selectLoadWasAttempted: test2LoadWasAttempted,
           selectIsLoading: test2IsLoading,
           selectIsSaving: test2IsSaving,
           selectLoadedAt: test2LoadedAt,
@@ -214,6 +220,8 @@ describe('buildState()', () => {
       expect(hasNoTestEntities).not.toEqual(hasNoTest2Entities);
       expect(testIsDeleting).not.toEqual(test2IsDeleting);
       expect(testIsDirty).not.toEqual(test2IsDirty);
+      expect(testHasBeenLoaded).not.toEqual(test2HasBeenLoaded);
+      expect(testLoadWasAttempted).not.toEqual(test2LoadWasAttempted);
       expect(testIsLoading).not.toEqual(test2IsLoading);
       expect(testIsSaving).not.toEqual(test2IsSaving);
       expect(testLoadedAt).not.toEqual(test2LoadedAt);

--- a/projects/ngrx-auto-entity/src/lib/util/util.spec.ts
+++ b/projects/ngrx-auto-entity/src/lib/util/util.spec.ts
@@ -44,6 +44,8 @@ const selectorProperties = [
   'selectCurrentPage',
   'selectCurrentRange',
   'selectTotalPageable',
+  'selectHasBeenLoaded',
+  'selectLoadWasAttempted',
   'selectIsLoading',
   'selectIsSaving',
   'selectIsDeleting',


### PR DESCRIPTION
    + Add selectHasBeenLoaded to track if the data has ever been loaded before
    + Add selectLoadWasAttempted to track if an attempt to load the data has ever been made
    ^ Bumped version to 0.8.1
    * Updated changelog to reflect latest changes
   
Issue #218