### PR TITLE
Hotfix/action creator props missmatch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 /dist
 /tmp
 /out-tsc
+.angular
 
 # dependencies
 /node_modules

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+<a name="12.0.0"></a>
+
+# [12.0.0](https://github.com/briebug/ngrx-auto-entity/compare/12.0.0-beta.1...12.0.0) Release (2022-06-01)
+
+Official v12 release with support for Angular 12, 10, 11 and 9 as well as the corresponding NgRx versions.
+
 <a name="12.0.0-beta.1"></a>
 
 # [12.0.0-beta.1](https://github.com/briebug/ngrx-auto-entity/compare/0.8.1...12.0.0-beta.1) Beta (2022-05-05)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,17 @@
+<a name="12.1.0"></a>
+
+# [12.1.0](https://github.com/briebug/ngrx-auto-entity/compare/12.0.0...12.1.0) Release (2022-10-11)
+
+Resolved discrepancies between class-based action constructor parameters and their corresponding action creator props.
+
+### Bug Fix
+
+- **factories:** Updated range loading success factory to include the missing rangeInfo parameter.
+- **factories:** Updated page loading success factory to include the missing pageInfo parameter.
+- **factories:** Updated range loading failure factory to include the missing range parameter.
+- **factories:** Updated page loading failure factory to include the missing page parameter.
+- **factories:** Updated selected factory to include the missing entity parameter.
+
 <a name="12.0.0"></a>
 
 # [12.0.0](https://github.com/briebug/ngrx-auto-entity/compare/12.0.0-beta.1...12.0.0) Release (2022-06-01)

--- a/projects/ngrx-auto-entity/README.md
+++ b/projects/ngrx-auto-entity/README.md
@@ -46,6 +46,8 @@ custom reducers.
 
 # Dependencies
 
+## Auto-Entity v12
+
 NgRx Auto-Entity v12 currently supports Angular 9-12, and the corresponding NgRx versions. Base version
 support is as follows:
 
@@ -54,12 +56,16 @@ support is as follows:
 [![Deps-NgRxStore](https://img.shields.io/badge/@ngrx/store-%5E9.x-blue.svg)](https://github.com/ngrx/platform)
 [![Deps-RxJs](https://img.shields.io/badge/rxjs-%5E6.x-blue.svg)](https://github.com/reactivex/rxjs)
 
+## Auto-Entity v13
+
 NgRx Auto-Entity v13 beta is currently being developed. Upon release, we expect it to support the following base versions:
 
 [![Deps-AngularCore](https://img.shields.io/badge/@angular/core-%5E13.x-blue.svg)](https://github.com/angular/angular)
 [![Deps-AngularCommon](https://img.shields.io/badge/@angular/common-%5E13.x-blue.svg)](https://github.com/angular/angular)
 [![Deps-NgRxStore](https://img.shields.io/badge/@ngrx/store-%5E13.x-blue.svg)](https://github.com/ngrx/platform)
 [![Deps-RxJs](https://img.shields.io/badge/rxjs-%5E7.x-blue.svg)](https://github.com/reactivex/rxjs)
+
+## Auto-Entity v14
 
 NgRx Auto-Entity v14 is currently being planned &amp; researched. We are hopeful that the next version of Auto-Entity
 will support both versions 13 and 14 of Angular & NgRx. 

--- a/projects/ngrx-auto-entity/package.json
+++ b/projects/ngrx-auto-entity/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "12.0.0-beta.1",
+  "version": "12.0.0",
   "name": "@briebug/ngrx-auto-entity",
   "description": "Automatic Entity State and Facades for NgRx. Simplifying reactive state!",
   "license": "SEE LICENSE IN LICENSE.md",

--- a/projects/ngrx-auto-entity/package.json
+++ b/projects/ngrx-auto-entity/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "12.0.0",
+  "version": "12.1.0",
   "name": "@briebug/ngrx-auto-entity",
   "description": "Automatic Entity State and Facades for NgRx. Simplifying reactive state!",
   "license": "SEE LICENSE IN LICENSE.md",

--- a/projects/ngrx-auto-entity/src/lib/factories/load-page-factories.ts
+++ b/projects/ngrx-auto-entity/src/lib/factories/load-page-factories.ts
@@ -2,7 +2,7 @@ import { ActionCreator } from '@ngrx/store';
 import { EntityActionTypes } from '../actions/action-types';
 import { TNew } from '../actions/model-constructor';
 import { setActionType } from '../actions/util';
-import { Page } from '../models';
+import { IPageInfo, Page } from '../models';
 import { cacheOnType, defineTypedFactoryFunction, StandardProps } from './util';
 import { LoadPage, LoadPageFailure, LoadPageIfNecessary, LoadPageSuccess } from '../actions/load-page-actions';
 
@@ -37,6 +37,7 @@ export const createLoadPageIfNecessaryAction = <TModel, T extends string, P exte
 
 export interface LoadPageSuccessProps<TModel> extends StandardProps {
   entities: TModel[];
+  pageInfo: IPageInfo;
 }
 
 export const createLoadPageSuccessAction = <TModel, T extends string, P extends LoadPageSuccessProps<TModel>>(
@@ -45,12 +46,13 @@ export const createLoadPageSuccessAction = <TModel, T extends string, P extends 
   cacheOnType(Type, EntityActionTypes.LoadPageSuccess, () =>
     defineTypedFactoryFunction(
       setActionType(EntityActionTypes.LoadPageSuccess, Type),
-      ({ entities, criteria, correlationId }: LoadPageSuccessProps<TModel>) => new LoadPageSuccess(Type, entities, criteria, correlationId)
+      ({ entities, pageInfo, criteria, correlationId }: LoadPageSuccessProps<TModel>) => new LoadPageSuccess(Type, entities, pageInfo, criteria, correlationId)
     )
   );
 
 export interface LoadPageFailureProps<TModel> extends StandardProps {
   error: any;
+  page: Page;
 }
 
 export const createLoadPageFailureAction = <TModel, T extends string, P extends LoadPageFailureProps<TModel>>(
@@ -59,6 +61,6 @@ export const createLoadPageFailureAction = <TModel, T extends string, P extends 
   cacheOnType(Type, EntityActionTypes.LoadPageFailure, () =>
     defineTypedFactoryFunction(
       setActionType(EntityActionTypes.LoadPageFailure, Type),
-      ({ error, criteria, correlationId }: LoadPageFailureProps<TModel>) => new LoadPageFailure(Type, error, criteria, correlationId)
+      ({ error, page, criteria, correlationId }: LoadPageFailureProps<TModel>) => new LoadPageFailure(Type, error, criteria, correlationId)
     )
   );

--- a/projects/ngrx-auto-entity/src/lib/factories/load-range-factories.ts
+++ b/projects/ngrx-auto-entity/src/lib/factories/load-range-factories.ts
@@ -2,7 +2,7 @@ import { ActionCreator } from '@ngrx/store';
 import { EntityActionTypes } from '../actions/action-types';
 import { TNew } from '../actions/model-constructor';
 import { setActionType } from '../actions/util';
-import { Range } from '../models';
+import { IRangeInfo, Range } from '../models';
 import { cacheOnType, defineTypedFactoryFunction, StandardProps } from './util';
 import { LoadRange, LoadRangeFailure, LoadRangeIfNecessary, LoadRangeSuccess } from '../actions/load-range-actions';
 
@@ -37,6 +37,7 @@ export const createLoadRangeIfNecessaryAction = <TModel, T extends string, P ext
 
 export interface LoadRangeSuccessProps<TModel> extends StandardProps {
   entities: TModel[];
+  rangeInfo: IRangeInfo;
 }
 
 export const createLoadRangeSuccessAction = <TModel, T extends string, P extends LoadRangeSuccessProps<TModel>>(
@@ -45,13 +46,14 @@ export const createLoadRangeSuccessAction = <TModel, T extends string, P extends
   cacheOnType(Type, EntityActionTypes.LoadRangeSuccess, () =>
     defineTypedFactoryFunction(
       setActionType(EntityActionTypes.LoadRangeSuccess, Type),
-      ({ entities, criteria, correlationId }: LoadRangeSuccessProps<TModel>) =>
-        new LoadRangeSuccess(Type, entities, criteria, correlationId)
+      ({ entities, rangeInfo, criteria, correlationId }: LoadRangeSuccessProps<TModel>) =>
+        new LoadRangeSuccess(Type, entities, rangeInfo, criteria, correlationId)
     )
   );
 
 export interface LoadRangeFailureProps<TModel> extends StandardProps {
   error: any;
+  range: Range;
 }
 
 export const createLoadRangeFailureAction = <TModel, T extends string, P extends LoadRangeFailureProps<TModel>>(
@@ -60,6 +62,7 @@ export const createLoadRangeFailureAction = <TModel, T extends string, P extends
   cacheOnType(Type, EntityActionTypes.LoadRangeFailure, () =>
     defineTypedFactoryFunction(
       setActionType(EntityActionTypes.LoadRangeFailure, Type),
-      ({ error, criteria, correlationId }: LoadRangeFailureProps<TModel>) => new LoadRangeFailure(Type, error, criteria, correlationId)
+      ({ error, range, criteria, correlationId }: LoadRangeFailureProps<TModel>) =>
+        new LoadRangeFailure(Type, error, range, criteria, correlationId)
     )
   );

--- a/projects/ngrx-auto-entity/src/lib/factories/selection-factories.ts
+++ b/projects/ngrx-auto-entity/src/lib/factories/selection-factories.ts
@@ -92,13 +92,17 @@ export const createSelectMoreByKeysAction = <TModel, T extends string, P extends
     )
   );
 
-export const createSelectedAction = <TModel, T extends string, P extends CorrelatedProps>(
+export interface SelectedProps<TModel> extends CorrelatedProps {
+  entity: TModel | EntityIdentity;
+}
+
+export const createSelectedAction = <TModel, T extends string, P extends SelectedProps<TModel>>(
   Type: TNew<TModel>
 ): ActionCreator<T, (props: CorrelatedProps) => Selected<TModel>> =>
   cacheOnType(Type, EntityActionTypes.Selected, () =>
     defineTypedFactoryFunction(
       setActionType(EntityActionTypes.Selected, Type),
-      ({ correlationId }: CorrelatedProps = {}) => new Selected(Type, correlationId)
+      ({ entity, correlationId }: SelectedProps<TModel>) => new Selected(Type, entity, correlationId)
     )
   );
 


### PR DESCRIPTION
#### What:

The action creator factories for Load Range Success/Failure, Load Page Success/Failure, & Selected use props that do not align with their class-based action counterpart. This updates the prop interfaces to match the constructors.