### PR TITLE
BAE-7: Adds Provider API

### DIFF
--- a/projects/ngrx-auto-entity-service/src/lib/config.ts
+++ b/projects/ngrx-auto-entity-service/src/lib/config.ts
@@ -3,8 +3,6 @@ import { EntityCriteria, RetryCriteria } from './critera.model';
 import { IEntityInfo } from '@briebug/ngrx-auto-entity';
 import { Observable } from 'rxjs';
 
-export type DynamicAutoEntityServiceConfig = (...deps: any[]) => AutoEntityServiceConfig;
-
 export type APIPrefixResolver = (
   operation: string,
   info: IEntityInfo,
@@ -52,4 +50,4 @@ export interface AutoEntityServiceConfig {
   defaultRetry?: RetryCriteria;
 }
 
-export const AUTO_ENTITY_CONFIG = new InjectionToken<AutoEntityServiceConfig>('auto-entity-config');
+export const AUTO_ENTITY_CONFIG = new InjectionToken<AutoEntityServiceConfig>('@briebug/ngrx-auto-entity-service Config');

--- a/projects/ngrx-auto-entity-service/src/lib/ngrx-auto-entity-service.module.ts
+++ b/projects/ngrx-auto-entity-service/src/lib/ngrx-auto-entity-service.module.ts
@@ -1,31 +1,20 @@
-import { ModuleWithProviders, NgModule, Provider } from '@angular/core';
+import { ModuleWithProviders, NgModule } from '@angular/core';
 import { HttpClientModule } from '@angular/common/http';
-import { EntityService } from './entity.service';
-import { AUTO_ENTITY_CONFIG, AutoEntityServiceConfig, DynamicAutoEntityServiceConfig } from './config';
-
-const createConfigProvider = (config: AutoEntityServiceConfig | DynamicAutoEntityServiceConfig, deps?: any[]): Provider =>
-  typeof config === 'function'
-    ? {
-        provide: AUTO_ENTITY_CONFIG,
-        useFactory: config,
-        deps
-      }
-    : { provide: AUTO_ENTITY_CONFIG, useValue: config };
+import { AutoEntityServiceConfig } from './config';
+import { _provideAutoEntityService } from './ngrx-auto-entity-service.provider';
 
 @NgModule({
-  imports: [HttpClientModule],
-  providers: [EntityService]
+  imports: [HttpClientModule]
 })
 export class NgrxAutoEntityServiceModule {
-  static forRoot(config: DynamicAutoEntityServiceConfig, deps?: any[]): ModuleWithProviders<NgrxAutoEntityServiceModule>;
   static forRoot(config: AutoEntityServiceConfig): ModuleWithProviders<NgrxAutoEntityServiceModule>;
-  static forRoot(
-    config: AutoEntityServiceConfig | DynamicAutoEntityServiceConfig,
-    deps?: any[]
-  ): ModuleWithProviders<NgrxAutoEntityServiceModule> {
+  static forRoot(config: () => AutoEntityServiceConfig): ModuleWithProviders<NgrxAutoEntityServiceModule>;
+  /** @deprecated use `inject` to provide dependencies */
+  static forRoot(config: (...deps: any[]) => AutoEntityServiceConfig, deps: any[]): ModuleWithProviders<NgrxAutoEntityServiceModule>;
+  static forRoot(config: AutoEntityServiceConfig | (() => AutoEntityServiceConfig)): ModuleWithProviders<NgrxAutoEntityServiceModule> {
     return {
       ngModule: NgrxAutoEntityServiceModule,
-      providers: [createConfigProvider(config, deps)]
+      providers: [..._provideAutoEntityService(config)]
     };
   }
 }

--- a/projects/ngrx-auto-entity-service/src/lib/ngrx-auto-entity-service.provider.ts
+++ b/projects/ngrx-auto-entity-service/src/lib/ngrx-auto-entity-service.provider.ts
@@ -1,0 +1,80 @@
+import { APP_INITIALIZER, EnvironmentProviders, inject, makeEnvironmentProviders, Provider } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { AUTO_ENTITY_CONFIG, AutoEntityServiceConfig } from './config';
+import { EntityService } from './entity.service';
+import { noop } from 'rxjs';
+
+declare const ngDevMode: unknown;
+
+/** @internal */
+export function _provideAutoEntityService(config: AutoEntityServiceConfig | (() => AutoEntityServiceConfig), deps?: any[]): Provider[] {
+  return [
+    EntityService,
+    typeof config === 'function'
+      ? { provide: AUTO_ENTITY_CONFIG, useFactory: config, deps }
+      : { provide: AUTO_ENTITY_CONFIG, useValue: config }
+  ];
+}
+
+/** @internal */
+export function _assertHttpClientProvided(): () => void {
+  const http = inject(HttpClient, { optional: true });
+  if (http == null) {
+    console.error("[NGRX-AES] ! No provider for HttpClient. Make sure `provideHttpClient()` is included in you application's providers.");
+  }
+  return noop;
+}
+
+/**
+ * Sets up providers for the auto-entity entity service.
+ *
+ * @usageNotes
+ *
+ * ### Providing Auto-Entity Service
+ *
+ * Basic example of using the Auto-Entity Entity Service with your entities:
+ * ```
+ * bootstrapApplication(AppComponent, {
+ *   providers: [
+ *     // …
+ *     provideAutoEntityService({
+ *       urlPrefix: 'https://example.com/api'
+ *     }),
+ *   ]
+ * });
+ * ```
+ *
+ * ### Dynamic configuration
+ *
+ * You can also provide the Auto-Entity Entity Service configuration dynamically:
+ * ```
+ * bootstrapApplication(AppComponent, {
+ *   providers: [
+ *     // …
+ *     provideAutoEntityService(() => {
+ *       const configService = inject(ConfigService);
+ *       return {
+ *         urlPrefix: configService.apiBaseUrl
+ *       }
+ *     })
+ *   ]
+ * });
+ * ```
+ *
+ * @publicApi
+ * @param config An Auto-Entity Entity Service configuration object or a function that returns an Auto-Entity Entity Service configuration object.
+ * @returns A set of providers to set up an Auto-Entity Service.
+ */
+export function provideAutoEntityService(config: AutoEntityServiceConfig | (() => AutoEntityServiceConfig)): EnvironmentProviders {
+  const providers: Provider[] = [];
+
+  if (typeof ngDevMode !== 'undefined' && ngDevMode) {
+    providers.push({
+      provide: APP_INITIALIZER,
+      useFactory: _assertHttpClientProvided,
+      multi: true
+    });
+  }
+
+  return makeEnvironmentProviders([...providers, ..._provideAutoEntityService(config)]);
+}

--- a/projects/ngrx-auto-entity-service/src/public_api.ts
+++ b/projects/ngrx-auto-entity-service/src/public_api.ts
@@ -3,6 +3,7 @@
  */
 
 export { NgrxAutoEntityServiceModule } from './lib/ngrx-auto-entity-service.module';
+export { provideAutoEntityService } from './lib/ngrx-auto-entity-service.provider';
 export { EntityService } from './lib/entity.service';
-export type { AutoEntityServiceConfig, DynamicAutoEntityServiceConfig, APIPrefixResolver } from './lib/config';
+export type { AutoEntityServiceConfig, APIPrefixResolver } from './lib/config';
 export type { EntityCriteria, RetryCriteria, QueryCriteria } from './lib/critera.model';

--- a/projects/ngrx-auto-entity/src/lib/module.spec.ts
+++ b/projects/ngrx-auto-entity/src/lib/module.spec.ts
@@ -1,0 +1,175 @@
+import { TestBed } from '@angular/core/testing';
+import { META_REDUCERS, MetaReducer, Store, StoreModule } from '@ngrx/store';
+import { EffectsModule, EffectSources } from '@ngrx/effects';
+
+import { EntityEffects } from './effects/effects-all';
+import { ExtraEffects } from './effects/effects-extra';
+import { EntityIfNecessaryOperators } from './effects/if-necessary-operators';
+import { EntityOperators } from './effects/operators';
+import { autoEntityMetaReducer } from './reducer/meta-reducer';
+import {
+  NgRxAutoEntityFeatureModule,
+  NgrxAutoEntityModule,
+  NgRxAutoEntityRootModuleNoEffects,
+  NgRxAutoEntityRootModuleNoEntityEffects,
+  NgRxAutoEntityRootModuleWithEffects
+} from './module';
+import { NEVER } from 'rxjs';
+import { NgrxAutoEntityService } from './service/service';
+import { NGRX_AUTO_ENTITY_APP_STORE } from './effects/if-necessary-operator-utils';
+
+let effectSources: EffectSources;
+let entityService: NgrxAutoEntityService | null;
+let entityOps: EntityOperators | null;
+let entityIfNecessaryOps: EntityIfNecessaryOperators | null;
+let entityEffects: EntityEffects | null;
+let extraEffects: ExtraEffects | null;
+let metaReducers: MetaReducer[] | null;
+let appStore: Store | null;
+
+beforeEach(() => {
+  effectSources = null;
+  entityService = null;
+  entityOps = null;
+  entityIfNecessaryOps = null;
+  entityEffects = null;
+  extraEffects = null;
+  metaReducers = null;
+  appStore = null;
+});
+
+function resolveDependencies() {
+  effectSources = TestBed.inject(EffectSources);
+  entityService = TestBed.inject(NgrxAutoEntityService, null, { optional: true });
+  entityOps = TestBed.inject(EntityOperators, null, { optional: true });
+  entityIfNecessaryOps = TestBed.inject(EntityIfNecessaryOperators, null, { optional: true });
+  entityEffects = TestBed.inject(EntityEffects, null, { optional: true });
+  extraEffects = TestBed.inject(ExtraEffects, null, { optional: true });
+  metaReducers = TestBed.inject(META_REDUCERS, null, { optional: true });
+  appStore = TestBed.inject(NGRX_AUTO_ENTITY_APP_STORE, null, { optional: true }) as Store;
+}
+
+const mockEffectSourcesProvider = {
+  useValue: {
+    addEffects: jest.fn(),
+    toActions: jest.fn().mockReturnValue(NEVER)
+  }
+};
+
+describe('Module: NgRxAutoEntityRootModuleWithEffects', () => {
+  it('should provide the correct dependencies', () => {
+    TestBed.configureTestingModule({
+      imports: [StoreModule.forRoot({}), EffectsModule.forRoot([]), NgrxAutoEntityModule.forRoot()]
+    }).overrideProvider(EffectSources, mockEffectSourcesProvider);
+
+    resolveDependencies();
+
+    expect(entityService).toBeDefined();
+    expect(entityOps).toBeDefined();
+    expect(entityIfNecessaryOps).toBeDefined();
+    expect(entityEffects).toBeDefined();
+    expect(extraEffects).toBeDefined();
+    expect(appStore).toBeNull();
+
+    expect(metaReducers).toContain(autoEntityMetaReducer);
+
+    expect(effectSources.addEffects).toHaveBeenCalledWith(entityEffects);
+    expect(effectSources.addEffects).toHaveBeenCalledWith(extraEffects);
+  });
+});
+
+describe('Module: NgRxAutoEntityRootModuleNoEntityEffects', () => {
+  it('should provide the correct dependencies', () => {
+    TestBed.configureTestingModule({
+      imports: [StoreModule.forRoot({}), EffectsModule.forRoot([]), NgrxAutoEntityModule.forRootNoEntityEffects()]
+    }).overrideProvider(EffectSources, mockEffectSourcesProvider);
+
+    resolveDependencies();
+
+    expect(entityService).toBeDefined();
+    expect(entityOps).toBeDefined();
+    expect(entityIfNecessaryOps).toBeDefined();
+    expect(entityEffects).toBeNull();
+    expect(extraEffects).toBeDefined();
+    expect(appStore).toBeNull();
+
+    expect(metaReducers).toContain(autoEntityMetaReducer);
+
+    expect(effectSources.addEffects).not.toHaveBeenCalledWith(entityEffects);
+    expect(effectSources.addEffects).toHaveBeenCalledWith(extraEffects);
+  });
+});
+
+describe('Module: NgRxAutoEntityRootModuleNoEffects', () => {
+  it('should provide the correct dependencies', () => {
+    TestBed.configureTestingModule({
+      imports: [StoreModule.forRoot({}), EffectsModule.forRoot([]), NgrxAutoEntityModule.forRootNoEffects()]
+    }).overrideProvider(EffectSources, mockEffectSourcesProvider);
+
+    const effectSources = TestBed.inject(EffectSources);
+
+    resolveDependencies();
+
+    expect(entityService).toBeDefined();
+    expect(entityOps).toBeDefined();
+    expect(entityIfNecessaryOps).toBeDefined();
+    expect(entityEffects).toBeNull();
+    expect(extraEffects).toBeNull();
+    expect(appStore).toBeNull();
+
+    expect(metaReducers).toContain(autoEntityMetaReducer);
+
+    expect(effectSources.addEffects).not.toHaveBeenCalledWith(entityEffects);
+    expect(effectSources.addEffects).not.toHaveBeenCalledWith(extraEffects);
+  });
+});
+
+describe('Module: NgRxAutoEntityFeatureModule', () => {
+  it('should provide the correct dependencies', () => {
+    TestBed.configureTestingModule({
+      imports: [NgrxAutoEntityModule.forFeature()]
+    });
+  });
+});
+
+describe('Module: NgrxAutoEntityModule', () => {
+  describe('Method: forRoot', () => {
+    it('should return the NgRxAutoEntityRootModuleWithEffects module with providers', () => {
+      const module = NgrxAutoEntityModule.forRoot();
+      expect(module).toEqual({
+        ngModule: NgRxAutoEntityRootModuleWithEffects,
+        providers: expect.any(Array)
+      });
+    });
+  });
+
+  describe('Method: forRootNoEntityEffects', () => {
+    it('should return the NgRxAutoEntityRootModuleNoEntityEffects module with providers', () => {
+      const module = NgrxAutoEntityModule.forRootNoEntityEffects();
+      expect(module).toEqual({
+        ngModule: NgRxAutoEntityRootModuleNoEntityEffects,
+        providers: expect.any(Array)
+      });
+    });
+  });
+
+  describe('Method: forRootNoEffects', () => {
+    it('should return the NgRxAutoEntityRootModuleNoEffects module with providers', () => {
+      const module = NgrxAutoEntityModule.forRootNoEffects();
+      expect(module).toEqual({
+        ngModule: NgRxAutoEntityRootModuleNoEffects,
+        providers: expect.any(Array)
+      });
+    });
+  });
+
+  describe('Method: forFeature', () => {
+    it('should return the NgRxAutoEntityFeatureModule module with providers', () => {
+      const module = NgrxAutoEntityModule.forFeature();
+      expect(module).toEqual({
+        ngModule: NgRxAutoEntityFeatureModule,
+        providers: expect.any(Array)
+      });
+    });
+  });
+});

--- a/projects/ngrx-auto-entity/src/lib/module.ts
+++ b/projects/ngrx-auto-entity/src/lib/module.ts
@@ -1,138 +1,57 @@
-import { Injector, ModuleWithProviders, NgModule } from '@angular/core';
-import { EffectSources } from '@ngrx/effects';
-import { META_REDUCERS } from '@ngrx/store';
+import { ModuleWithProviders, NgModule } from '@angular/core';
 
-import { EntityEffects } from './effects/effects-all';
-import { ExtraEffects } from './effects/effects-extra';
-import { EntityIfNecessaryOperators } from './effects/if-necessary-operators';
-import { EntityOperators } from './effects/operators';
-import { autoEntityMetaReducer } from './reducer/meta-reducer';
-import { NgrxAutoEntityService } from './service/service';
-import { addInjector } from './service/service-injection';
-
-export function getNgRxAutoEntityMetaReducer() {
-  return autoEntityMetaReducer;
-}
+import {
+  _provideAutoEntityState,
+  _provideAutoEntityStore,
+  _withoutCustomStore,
+  withoutEntityEffects,
+  withoutExtraEffects
+} from './provider';
 
 // eslint-disable-next-line @typescript-eslint/naming-convention
 export interface NgRxAutoEntityModuleConfig {
   excludeEffects?: boolean;
 }
 
-@NgModule({
-  providers: [
-    EntityOperators,
-    EntityIfNecessaryOperators,
-    EntityEffects,
-    ExtraEffects,
-    { provide: META_REDUCERS, useFactory: getNgRxAutoEntityMetaReducer, multi: true }
-  ]
-})
-export class NgRxAutoEntityRootModuleWithEffects {
-  constructor(private effectSources: EffectSources, entityEffects: EntityEffects, extraEffects: ExtraEffects) {
-    // NOTE: The following trick learned from @ngrx/data!
-
-    // Warning: this alternative approach relies on an undocumented API
-    // to add effect directly rather than through `forFeature()`.
-    // The danger is that EffectsModule.forFeature evolves and we no longer perform a crucial step.
-    this.addEffects(entityEffects);
-    this.addEffects(extraEffects);
-  }
-
-  /**
-   * Add another class instance that contains @Effect methods.
-   * @param effectSourceInstance a class instance that implements effects.
-   * Warning: undocumented @ngrx/effects API
-   */
-  addEffects(effectSourceInstance: any) {
-    this.effectSources.addEffects(effectSourceInstance);
-  }
-}
-
-@NgModule({
-  providers: [
-    EntityOperators,
-    EntityIfNecessaryOperators,
-    ExtraEffects,
-    { provide: META_REDUCERS, useFactory: getNgRxAutoEntityMetaReducer, multi: true }
-  ]
-})
-export class NgRxAutoEntityRootModuleNoEntityEffects {
-  constructor(private effectSources: EffectSources, extraEffects: ExtraEffects) {
-    // NOTE: The following trick learned from @ngrx/data!
-
-    // Warning: this alternative approach relies on an undocumented API
-    // to add effect directly rather than through `forFeature()`.
-    // The danger is that EffectsModule.forFeature evolves and we no longer perform a crucial step.
-    this.addEffects(extraEffects);
-  }
-
-  /**
-   * Add another class instance that contains @Effect methods.
-   * @param effectSourceInstance a class instance that implements effects.
-   * Warning: undocumented @ngrx/effects API
-   */
-  addEffects(effectSourceInstance: any) {
-    this.effectSources.addEffects(effectSourceInstance);
-  }
-}
-
-@NgModule({
-  providers: [
-    EntityOperators,
-    EntityIfNecessaryOperators,
-    ExtraEffects,
-    { provide: META_REDUCERS, useFactory: getNgRxAutoEntityMetaReducer, multi: true }
-  ]
-})
-export class NgRxAutoEntityRootModuleNoEffects {}
-
-let INJECTOR_DEPTH = 0;
+@NgModule({})
+export class NgRxAutoEntityRootModuleWithEffects {}
 
 @NgModule({})
-export class NgRxAutoEntityFeatureModule {
-  constructor(injector: Injector) {
-    // Update the core NgRxAutoEntityService INJECTORS to include the current injector
-    // This creates a list of injectors that should eventually encompass the entire application
-    // as lazy loaded modules are subsequently created, to be evaluated in reverse order
-    INJECTOR_DEPTH = INJECTOR_DEPTH + 1;
-    addInjector(
-      Injector.create({
-        providers: [],
-        parent: injector,
-        name: 'AutoEntityInjector' + INJECTOR_DEPTH
-      })
-    );
-  }
-}
+export class NgRxAutoEntityRootModuleNoEntityEffects {}
+
+@NgModule({})
+export class NgRxAutoEntityRootModuleNoEffects {}
+
+@NgModule({})
+export class NgRxAutoEntityFeatureModule {}
 
 @NgModule({})
 export class NgrxAutoEntityModule {
   static forRoot(): ModuleWithProviders<NgRxAutoEntityRootModuleWithEffects> {
     return {
       ngModule: NgRxAutoEntityRootModuleWithEffects,
-      providers: [NgrxAutoEntityService]
+      providers: _provideAutoEntityStore([_withoutCustomStore()])
     };
   }
 
   static forRootNoEntityEffects(): ModuleWithProviders<NgRxAutoEntityRootModuleNoEntityEffects> {
     return {
       ngModule: NgRxAutoEntityRootModuleNoEntityEffects,
-      providers: [NgrxAutoEntityService]
+      providers: _provideAutoEntityStore([withoutEntityEffects(), _withoutCustomStore()])
     };
   }
 
   static forRootNoEffects(): ModuleWithProviders<NgRxAutoEntityRootModuleNoEffects> {
     return {
       ngModule: NgRxAutoEntityRootModuleNoEffects,
-      providers: [NgrxAutoEntityService]
+      providers: _provideAutoEntityStore([withoutEntityEffects(), withoutExtraEffects(), _withoutCustomStore()])
     };
   }
 
   static forFeature(): ModuleWithProviders<NgRxAutoEntityFeatureModule> {
     return {
       ngModule: NgRxAutoEntityFeatureModule,
-      providers: [NgrxAutoEntityService]
+      providers: _provideAutoEntityState()
     };
   }
 }

--- a/projects/ngrx-auto-entity/src/lib/provider.spec.ts
+++ b/projects/ngrx-auto-entity/src/lib/provider.spec.ts
@@ -1,0 +1,310 @@
+import { TestBed } from '@angular/core/testing';
+import { META_REDUCERS, MetaReducer, provideStore, Store } from '@ngrx/store';
+import { identity, NEVER } from 'rxjs';
+import { EffectSources, provideEffects } from '@ngrx/effects';
+import { EntityIfNecessaryOperators } from './effects/if-necessary-operators';
+import { ENVIRONMENT_INITIALIZER, Injectable } from '@angular/core';
+import {
+  _resetInjectorDepth,
+  _resetProvidedServices,
+  addNgRxAutoEntityInjector,
+  getNgRxAutoEntityMetaReducer,
+  NgRxAutoEntityFeatureKind,
+  provideAutoEntityState,
+  provideAutoEntityStore,
+  provideEntityService,
+  withCustomStore,
+  withoutEntityEffects,
+  withoutExtraEffects
+} from './provider';
+import { getInjectors, resetInjectors } from './service/service-injection';
+import { Entity } from './decorators/entity-decorator';
+import { Key } from './decorators/key-decorator';
+import { NgrxAutoEntityService } from './service/service';
+import { EntityOperators } from './effects/operators';
+import { ExtraEffects } from './effects/effects-extra';
+import { NGRX_AUTO_ENTITY_APP_STORE } from './effects/if-necessary-operator-utils';
+import { EntityEffects } from './effects/effects-all';
+import { autoEntityMetaReducer } from './reducer/meta-reducer';
+
+@Injectable()
+class MyStore extends Store {}
+
+@Entity({ modelName: 'Test' })
+class Test {
+  @Key id: number;
+}
+
+@Entity({ modelName: 'Alt' })
+class Alt {
+  @Key id: number;
+}
+
+@Injectable()
+class TestService {}
+
+@Injectable()
+class AltService {}
+
+describe('Function: getNgRxAutoEntityMetaReducer', () => {
+  it('should return the autoEntityMetaReducer', () => {
+    expect(getNgRxAutoEntityMetaReducer()).toBe(autoEntityMetaReducer);
+  });
+});
+
+describe('Function: provideAutoEntityStore', () => {
+  let effectSources: EffectSources;
+  let entityService: NgrxAutoEntityService | null;
+  let entityOps: EntityOperators | null;
+  let entityIfNecessaryOps: EntityIfNecessaryOperators | null;
+  let entityEffects: EntityEffects | null;
+  let extraEffects: ExtraEffects | null;
+  let metaReducers: MetaReducer[] | null;
+  let appStore: Store | null;
+
+  beforeEach(() => {
+    effectSources = null;
+    entityService = null;
+    entityOps = null;
+    entityIfNecessaryOps = null;
+    entityEffects = null;
+    extraEffects = null;
+    metaReducers = null;
+    appStore = null;
+  });
+
+  function resolveDependencies() {
+    effectSources = TestBed.inject(EffectSources);
+    entityService = TestBed.inject(NgrxAutoEntityService, null, { optional: true });
+    entityOps = TestBed.inject(EntityOperators, null, { optional: true });
+    entityIfNecessaryOps = TestBed.inject(EntityIfNecessaryOperators, null, { optional: true });
+    entityEffects = TestBed.inject(EntityEffects, null, { optional: true });
+    extraEffects = TestBed.inject(ExtraEffects, null, { optional: true });
+    metaReducers = TestBed.inject(META_REDUCERS, null, { optional: true });
+    appStore = TestBed.inject(NGRX_AUTO_ENTITY_APP_STORE, null, { optional: true }) as Store;
+  }
+
+  const mockEffectSourcesProvider = {
+    useValue: {
+      addEffects: jest.fn(),
+      toActions: jest.fn().mockReturnValue(NEVER)
+    }
+  };
+
+  // NOTE: Parity with NgRxAutoEntityRootModuleWithEffects
+  describe('Features: none', () => {
+    it('should provide the correct dependencies', () => {
+      TestBed.configureTestingModule({
+        providers: [provideStore(identity), provideEffects(), provideAutoEntityStore()]
+      }).overrideProvider(EffectSources, mockEffectSourcesProvider);
+
+      resolveDependencies();
+
+      expect(entityService).toBeDefined();
+      expect(entityOps).toBeDefined();
+      expect(entityIfNecessaryOps).toBeDefined();
+      expect(entityEffects).toBeDefined();
+      expect(extraEffects).toBeDefined();
+      expect(appStore).toBeDefined();
+      expect(appStore).toBeInstanceOf(Store);
+
+      expect(metaReducers).toContain(autoEntityMetaReducer);
+
+      expect(effectSources.addEffects).toHaveBeenCalledWith(entityEffects);
+      expect(effectSources.addEffects).toHaveBeenCalledWith(extraEffects);
+    });
+  });
+
+  describe('Feature: withCustomStore', () => {
+    it('should provide the correct dependencies', () => {
+      TestBed.configureTestingModule({
+        providers: [MyStore, provideStore(identity), provideEffects(), provideAutoEntityStore(withCustomStore(MyStore))]
+      }).overrideProvider(EffectSources, mockEffectSourcesProvider);
+
+      resolveDependencies();
+
+      expect(entityService).toBeDefined();
+      expect(entityOps).toBeDefined();
+      expect(entityIfNecessaryOps).toBeDefined();
+      expect(entityEffects).toBeDefined();
+      expect(extraEffects).toBeDefined();
+      expect(appStore).toBeDefined();
+      expect(appStore).toBeInstanceOf(MyStore);
+
+      expect(metaReducers).toContain(autoEntityMetaReducer);
+
+      expect(effectSources.addEffects).toHaveBeenCalledWith(entityEffects);
+      expect(effectSources.addEffects).toHaveBeenCalledWith(extraEffects);
+    });
+  });
+
+  // NOTE: Parity with NgRxAutoEntityRootModuleNoEntityEffects
+  describe('Feature: withoutEntityEffects', () => {
+    it('should exclude EntityEffects from the providers list', () => {
+      TestBed.configureTestingModule({
+        providers: [provideStore(identity), provideEffects(), provideAutoEntityStore(withoutEntityEffects())]
+      }).overrideProvider(EffectSources, mockEffectSourcesProvider);
+
+      resolveDependencies();
+
+      expect(entityService).toBeDefined();
+      expect(entityOps).toBeDefined();
+      expect(entityIfNecessaryOps).toBeDefined();
+      expect(entityEffects).toBeNull();
+      expect(extraEffects).toBeDefined();
+      expect(appStore).toBeDefined();
+
+      expect(metaReducers).toContain(autoEntityMetaReducer);
+
+      expect(effectSources.addEffects).not.toHaveBeenCalledWith(entityEffects);
+      expect(effectSources.addEffects).toHaveBeenCalledWith(extraEffects);
+    });
+  });
+
+  describe('Feature: withoutExtraEffects', () => {
+    it('should exclude ExtraEffects from the providers list', () => {
+      TestBed.configureTestingModule({
+        providers: [provideStore(identity), provideEffects(), provideAutoEntityStore(withoutExtraEffects())]
+      }).overrideProvider(EffectSources, mockEffectSourcesProvider);
+
+      resolveDependencies();
+
+      expect(entityService).toBeDefined();
+      expect(entityOps).toBeDefined();
+      expect(entityIfNecessaryOps).toBeDefined();
+      expect(entityEffects).toBeDefined();
+      expect(extraEffects).toBeNull();
+      expect(appStore).toBeDefined();
+
+      expect(metaReducers).toContain(autoEntityMetaReducer);
+
+      expect(effectSources.addEffects).toHaveBeenCalledWith(entityEffects);
+      expect(effectSources.addEffects).not.toHaveBeenCalledWith(extraEffects);
+    });
+  });
+
+  // NOTE: Parity with NgRxAutoEntityRootModuleNoEffects
+  describe('Features: withoutEntityEffects, withoutExtraEffects', () => {
+    it('should exclude EntityEffects and ExtraEffects from the providers list', () => {
+      TestBed.configureTestingModule({
+        providers: [provideStore(identity), provideEffects(), provideAutoEntityStore(withoutEntityEffects(), withoutExtraEffects())]
+      }).overrideProvider(EffectSources, mockEffectSourcesProvider);
+
+      resolveDependencies();
+
+      expect(entityService).toBeDefined();
+      expect(entityOps).toBeDefined();
+      expect(entityIfNecessaryOps).toBeDefined();
+      expect(entityEffects).toBeNull();
+      expect(extraEffects).toBeNull();
+      expect(appStore).toBeDefined();
+
+      expect(metaReducers).toContain(autoEntityMetaReducer);
+
+      expect(effectSources.addEffects).not.toHaveBeenCalledWith(entityEffects);
+      expect(effectSources.addEffects).not.toHaveBeenCalledWith(extraEffects);
+    });
+  });
+});
+
+describe('Function: withCustomStore', () => {
+  it('should return a CustomStoreFeature providing NGRX_AUTO_ENTITY_APP_STORE', () => {
+    const feature = withCustomStore(MyStore);
+    expect(feature).toEqual({
+      ɵkind: NgRxAutoEntityFeatureKind.CustomStoreFeature,
+      ɵproviders: [{ provide: NGRX_AUTO_ENTITY_APP_STORE, useExisting: MyStore }]
+    });
+  });
+});
+
+describe('Function: withoutEntityEffects', () => {
+  it('should return an EntityEffectsFeature providing nothing', () => {
+    const feature = withoutEntityEffects();
+    expect(feature).toEqual({
+      ɵkind: NgRxAutoEntityFeatureKind.EntityEffectsFeature,
+      ɵproviders: []
+    });
+  });
+});
+
+describe('Function: withoutExtraEffects', () => {
+  it('should return an ExtraEffectsFeature providing nothing', () => {
+    const feature = withoutExtraEffects();
+    expect(feature).toEqual({
+      ɵkind: NgRxAutoEntityFeatureKind.ExtraEffectsFeature,
+      ɵproviders: []
+    });
+  });
+});
+
+describe('Function: provideAutoEntityState', () => {
+  beforeEach(() => {
+    resetInjectors();
+    _resetInjectorDepth();
+  });
+
+  it("should provide an environment initializer to register the environment's injector", () => {
+    TestBed.configureTestingModule({
+      providers: [provideAutoEntityState()]
+    });
+
+    const environmentInitializers = TestBed.inject(ENVIRONMENT_INITIALIZER);
+    expect(environmentInitializers).toContain(addNgRxAutoEntityInjector);
+  });
+});
+
+describe('Function: addNgRxAutoEntityInjector', () => {
+  beforeEach(() => {
+    resetInjectors();
+    _resetInjectorDepth();
+  });
+
+  it("should register the environment's injector", () => {
+    TestBed.runInInjectionContext(() => {
+      addNgRxAutoEntityInjector();
+    });
+
+    const injectors = getInjectors();
+    expect(injectors).toHaveLength(1);
+    const injector = injectors[0]!;
+    expect((injector as any).source).toBe('AutoEntityInjector1');
+  });
+});
+
+describe('Function: provideEntityService', () => {
+  afterEach(() => {
+    _resetProvidedServices();
+  });
+
+  it('should provide a service using the entity as the token', () => {
+    TestBed.configureTestingModule({
+      providers: [provideEntityService(Test, TestService)]
+    });
+
+    const service = TestBed.inject(Test);
+    expect(service).toBeDefined();
+  });
+
+  it('should support providing multiple services', () => {
+    TestBed.configureTestingModule({
+      providers: [provideEntityService(Test, TestService), provideEntityService(Alt, AltService)]
+    });
+
+    const testService = TestBed.inject(Test);
+    expect(testService).toBeDefined();
+
+    const altService = TestBed.inject(Alt);
+    expect(altService).toBeDefined();
+  });
+
+  it('should use existing service instances for entities using the same service class', () => {
+    TestBed.configureTestingModule({
+      providers: [provideEntityService(Test, TestService), provideEntityService(Alt, TestService)]
+    });
+
+    const testService = TestBed.inject(Test);
+    const altService = TestBed.inject(Test);
+
+    expect(testService).toBe(altService);
+  });
+});

--- a/projects/ngrx-auto-entity/src/lib/provider.ts
+++ b/projects/ngrx-auto-entity/src/lib/provider.ts
@@ -1,0 +1,325 @@
+import {
+  ENVIRONMENT_INITIALIZER,
+  EnvironmentProviders,
+  inject,
+  InjectionToken,
+  Injector,
+  makeEnvironmentProviders,
+  Provider,
+  ProviderToken,
+  Type
+} from '@angular/core';
+import { META_REDUCERS, Store } from '@ngrx/store';
+import { EffectSources } from '@ngrx/effects';
+
+import { EntityEffects } from './effects/effects-all';
+import { ExtraEffects } from './effects/effects-extra';
+import { EntityIfNecessaryOperators } from './effects/if-necessary-operators';
+import { EntityOperators } from './effects/operators';
+import { autoEntityMetaReducer } from './reducer/meta-reducer';
+import { NgrxAutoEntityService } from './service/service';
+import { addInjector } from './service/service-injection';
+import { NGRX_AUTO_ENTITY_APP_STORE } from './effects/if-necessary-operator-utils';
+import { noop } from 'rxjs';
+
+declare const ngDevMode: unknown;
+
+/** @internal */
+export function _assertProvider(token: ProviderToken<unknown>, message: string): void {
+  if (inject(token, { optional: true }) == null) {
+    console.error(message);
+  }
+}
+
+/** @internal */
+export function _assertStoreProvided(): () => void {
+  _assertProvider(Store, "[NGRX-AE] ! No provider for Store. Make sure `provideStore()` is included in you application's providers.");
+  return noop;
+}
+
+/** @internal */
+export function _assertEffectSourcesProvided(): () => void {
+  _assertProvider(
+    EffectSources,
+    "[NGRX-AE] ! No provider for EffectSources. Make sure `provideEffects()` is included in you application's providers."
+  );
+  return noop;
+}
+
+export interface NgRxAutoEntityFeature<FeatureKind extends NgRxAutoEntityFeatureKind> {
+  ɵkind: FeatureKind;
+  ɵproviders: Provider[];
+}
+
+/** @internal */
+export function _isAutoEntityFeature<FeatureKind extends NgRxAutoEntityFeatureKind>(
+  value: any
+): value is NgRxAutoEntityFeature<FeatureKind> {
+  return value && value.ɵkind != null && value.ɵproviders != null;
+}
+
+/** @internal */
+export function _includesFeature<FeatureKind extends NgRxAutoEntityFeatureKind>(
+  features: NgRxAutoEntityFeatures[],
+  featureKind: FeatureKind
+): boolean {
+  return features.some(feature => feature.ɵkind === featureKind);
+}
+
+/** @internal */
+export function _autoEntityFeature<FeatureKind extends NgRxAutoEntityFeatureKind>(
+  kind: FeatureKind,
+  providers: Provider[]
+): NgRxAutoEntityFeature<FeatureKind> {
+  return { ɵkind: kind, ɵproviders: providers };
+}
+
+export function getNgRxAutoEntityMetaReducer() {
+  return autoEntityMetaReducer;
+}
+
+/** @internal */
+export function _provideAutoEntityStore(features: NgRxAutoEntityFeatures[] = []): Provider[] {
+  const providers: Provider[] = [];
+
+  if (!_includesFeature(features, NgRxAutoEntityFeatureKind.EntityEffectsFeature)) {
+    features.push(_withEntityEffects());
+  }
+
+  if (!_includesFeature(features, NgRxAutoEntityFeatureKind.ExtraEffectsFeature)) {
+    features.push(_withExtraEffects());
+  }
+
+  if (!_includesFeature(features, NgRxAutoEntityFeatureKind.CustomStoreFeature)) {
+    providers.push({
+      provide: NGRX_AUTO_ENTITY_APP_STORE,
+      useFactory: () => inject(Store)
+    });
+  }
+
+  if (typeof ngDevMode !== 'undefined' && ngDevMode) {
+    providers.push({
+      provide: ENVIRONMENT_INITIALIZER,
+      useFactory: _assertStoreProvided,
+      multi: true
+    });
+  }
+
+  return [
+    NgrxAutoEntityService,
+    EntityOperators,
+    EntityIfNecessaryOperators,
+    { provide: META_REDUCERS, useFactory: getNgRxAutoEntityMetaReducer, multi: true },
+    ...providers,
+    ...features.map(feature => feature.ɵproviders)
+  ];
+}
+
+/**
+ * Provides the global Auto-Entity providers.
+ *
+ * @usageNotes
+ *
+ * ### Providing Auto-Entity
+ *
+ * ```
+ * bootstrapApplication(AppComponent, {
+ *   providers: [
+ *     provideStore(appReducer)
+ *     provideAutoEntityStore(),
+ *   ]
+ * })
+ * ```
+ *
+ * @publicApi
+ * @param features A list of Auto-Entity features to include.
+ * @returns A set of providers to set up the Auto-Entity global state.
+ */
+export function provideAutoEntityStore(...features: NgRxAutoEntityFeatures[]): EnvironmentProviders {
+  return makeEnvironmentProviders(_provideAutoEntityStore(features));
+}
+
+let INJECTOR_DEPTH = 0;
+
+/** @internal */
+export function _resetInjectorDepth() {
+  INJECTOR_DEPTH = 0;
+}
+
+export function addNgRxAutoEntityInjector() {
+  const injector = inject(Injector);
+
+  // Update the core NgRxAutoEntityService INJECTORS to include the current injector
+  // This creates a list of injectors that should eventually encompass the entire application
+  // as +feature loaded modules are subsequently created, to be evaluated in reverse order
+  INJECTOR_DEPTH = INJECTOR_DEPTH + 1;
+  addInjector(
+    Injector.create({
+      providers: [],
+      parent: injector,
+      name: 'AutoEntityInjector' + INJECTOR_DEPTH
+    })
+  );
+}
+
+/** @internal */
+export function _provideAutoEntityState(): Provider[] {
+  return [
+    {
+      provide: ENVIRONMENT_INITIALIZER,
+      multi: true,
+      useValue: addNgRxAutoEntityInjector
+    }
+  ];
+}
+
+/**
+ * Provides the feature level Auto-Entity providers.
+ *
+ * @usageNotes
+ *
+ * ### Providing an Auto-Entity Feature State
+ *
+ * ```
+ * provideState(featureState),
+ * provideAutoEntityState()
+ * ```
+ *
+ * @publicApi
+ * @returns A set of providers to set up an Auto-Entity feature state.
+ */
+export function provideAutoEntityState(): EnvironmentProviders {
+  return makeEnvironmentProviders(_provideAutoEntityState());
+}
+
+let PROVIDED_SERVICES: Type<any>[] = [];
+
+/** @internal */
+export function _resetProvidedServices() {
+  PROVIDED_SERVICES = [];
+}
+
+/**
+ * Provides an entity's service.
+ *
+ * This will reuse existing services when possible.
+ *
+ * @usageNotes
+ *
+ * ### Providing an Entity's Service
+ *
+ * ```
+ * provideEntityService(Products, ProductsService)
+ * ```
+ *
+ * @publicApi
+ * @param modelType The entity model to provide a service for.
+ * @param service The service to provide.
+ * @returns A set of providers to set up an entity's service.
+ */
+export function provideEntityService(modelType: Type<any>, service: Type<any>): EnvironmentProviders {
+  const providers: Provider[] = [{ provide: modelType, useExisting: service }];
+
+  if (!PROVIDED_SERVICES.includes(service)) {
+    providers.unshift(service);
+    PROVIDED_SERVICES.push(service);
+  }
+
+  return makeEnvironmentProviders(providers);
+}
+
+export type CustomStoreFeature = NgRxAutoEntityFeature<NgRxAutoEntityFeatureKind.CustomStoreFeature>;
+
+/**
+ * Customize the provided Auto-Entity Store.
+ * @param storeProvider
+ */
+export function withCustomStore(storeProvider: Type<Store> | InjectionToken<Store>): CustomStoreFeature {
+  const providers = [{ provide: NGRX_AUTO_ENTITY_APP_STORE, useExisting: storeProvider }];
+  return _autoEntityFeature(NgRxAutoEntityFeatureKind.CustomStoreFeature, providers);
+}
+
+/**
+ * Disables automatic providing of the Auto-Entity Store.
+ * @internal
+ */
+export function _withoutCustomStore(): CustomStoreFeature {
+  return _autoEntityFeature(NgRxAutoEntityFeatureKind.CustomStoreFeature, []);
+}
+
+export type EntityEffectsFeature = NgRxAutoEntityFeature<NgRxAutoEntityFeatureKind.EntityEffectsFeature>;
+
+function addNgRxAutoEntityEntityEffects(): void {
+  const effectSources = inject(EffectSources);
+  const entityEffects = inject(EntityEffects);
+  // WARNING: `addEffects` is an undocumented API.
+  effectSources.addEffects(entityEffects);
+}
+
+/** @internal */
+export function _withEntityEffects(): EntityEffectsFeature {
+  const providers: Provider[] = [
+    EntityEffects,
+    {
+      provide: ENVIRONMENT_INITIALIZER,
+      useValue: addNgRxAutoEntityEntityEffects,
+      multi: true
+    }
+  ];
+
+  if (typeof ngDevMode !== 'undefined' && ngDevMode) {
+    providers.push({
+      provide: ENVIRONMENT_INITIALIZER,
+      useFactory: _assertEffectSourcesProvided,
+      multi: true
+    });
+  }
+
+  return _autoEntityFeature(NgRxAutoEntityFeatureKind.EntityEffectsFeature, providers);
+}
+
+/**
+ * Prevent Auto-Entity from registering its entity effects.
+ */
+export function withoutEntityEffects(): EntityEffectsFeature {
+  return _autoEntityFeature(NgRxAutoEntityFeatureKind.EntityEffectsFeature, []);
+}
+
+export type ExtraEffectsFeature = NgRxAutoEntityFeature<NgRxAutoEntityFeatureKind.ExtraEffectsFeature>;
+
+function addNgRxAutoEntityExtraEffects(): void {
+  const effectSources = inject(EffectSources);
+  const extraEffects = inject(ExtraEffects);
+  // WARNING: `addEffects` is an undocumented API.
+  effectSources.addEffects(extraEffects);
+}
+
+/** @internal */
+export function _withExtraEffects(): ExtraEffectsFeature {
+  const providers = [
+    ExtraEffects,
+    {
+      provide: ENVIRONMENT_INITIALIZER,
+      useValue: addNgRxAutoEntityExtraEffects,
+      multi: true
+    }
+  ];
+  return _autoEntityFeature(NgRxAutoEntityFeatureKind.ExtraEffectsFeature, providers);
+}
+
+/**
+ * Prevent Auto-Entity from registering its extra effects.
+ *
+ * This includes all select, deselect, and edit effects.
+ */
+export function withoutExtraEffects(): ExtraEffectsFeature {
+  return _autoEntityFeature(NgRxAutoEntityFeatureKind.ExtraEffectsFeature, []);
+}
+
+export type NgRxAutoEntityFeatures = CustomStoreFeature | EntityEffectsFeature | ExtraEffectsFeature;
+
+export const enum NgRxAutoEntityFeatureKind {
+  CustomStoreFeature,
+  EntityEffectsFeature,
+  ExtraEffectsFeature
+}

--- a/projects/ngrx-auto-entity/src/lib/reducer/meta-reducer.ts
+++ b/projects/ngrx-auto-entity/src/lib/reducer/meta-reducer.ts
@@ -5,7 +5,7 @@ import { autoEntityReducer } from './reducer';
 /**
  * Provides standard reducer functions to support entity store structure
  *
- * @param reducer: The next reducer to be applied
+ * @param reducer - The next reducer to be applied
  */
 export function autoEntityMetaReducer(reducer: ActionReducer<any>): ActionReducer<any> {
   return (state, action: EntityActions<any>) => {

--- a/projects/ngrx-auto-entity/src/public_api.ts
+++ b/projects/ngrx-auto-entity/src/public_api.ts
@@ -12,8 +12,20 @@ export {
   NgRxAutoEntityRootModuleNoEffects,
   NgRxAutoEntityFeatureModule,
   NgRxAutoEntityModuleConfig,
-  getNgRxAutoEntityMetaReducer
 } from './lib/module';
+export {
+  CustomStoreFeature,
+  EntityEffectsFeature,
+  ExtraEffectsFeature,
+  getNgRxAutoEntityMetaReducer,
+  NgRxAutoEntityFeatures,
+  provideAutoEntityState,
+  provideAutoEntityStore,
+  provideEntityService,
+  withCustomStore,
+  withoutEntityEffects,
+  withoutExtraEffects
+} from './lib/provider';
 
 /*
  * Injection Tokens


### PR DESCRIPTION
#### Summary:

Adds a provider API in addition to the previous module API. The module API has been implemented using the provider's API.

#### Example:

```typescript
export const appConfig: ApplicationConfig = {
  providers: [
    provideStore({
      customers: customerReducer,
    }),
    provideAutoEntityStore(),
    provideAutoEntityService({
      urlPrefix: environment.apiBaseUrl
    }),
    provideEntityService(Customer, EntityService),
  ]
};
```

| Before | After |
| --- | --- |
| <pre>NgrxAutoEntityModule.forRoot()</pre> | <pre>provideAutoEntityStore()</pre> |
| <pre>NgrxAutoEntityModule.forRootNoEntityEffects()</pre> | <pre>provideAutoEntityStore(withoutEntityEffects())</pre> |
| <pre>NgrxAutoEntityModule.forRootNoEffects()</pre> | <pre>provideAutoEntityStore(withoutEntityEffects(), withoutExtraEffects())</pre> |
| <pre>NgrxAutoEntityModule.forFeature()</pre> | <pre>provideAutoEntityState()</pre> |
| <pre>NgrxAutoEntityServiceModule.forRoot((config) => {<br>&nbsp;&nbsp;return {<br>&nbsp;&nbsp;&nbsp;&nbsp;urlPrefix: config.apiBaseUrl<br>&nbsp;&nbsp;};<br>})</pre> | <pre>provideAutoEntityService(() => {<br>&nbsp;&nbsp;const config = inject(ConfigService);<br>&nbsp;&nbsp;return {<br>&nbsp;&nbsp;&nbsp;&nbsp;urlPrefix: config.apiBaseUrl<br>&nbsp;&nbsp;};<br>})</pre> |
