### PR TITLE
Fix angular 17 updates

### DIFF
--- a/projects/ngrx-auto-entity-service/src/lib/ngrx-auto-entity-service.module.ts
+++ b/projects/ngrx-auto-entity-service/src/lib/ngrx-auto-entity-service.module.ts
@@ -8,10 +8,13 @@ export class NgrxAutoEntityServiceModule {
   static forRoot(config: () => AutoEntityServiceConfig): ModuleWithProviders<NgrxAutoEntityServiceModule>;
   /** @deprecated use `inject` to provide dependencies */
   static forRoot(config: (...deps: any[]) => AutoEntityServiceConfig, deps: any[]): ModuleWithProviders<NgrxAutoEntityServiceModule>;
-  static forRoot(config: AutoEntityServiceConfig | (() => AutoEntityServiceConfig)): ModuleWithProviders<NgrxAutoEntityServiceModule> {
+  static forRoot(
+    config: AutoEntityServiceConfig | (() => AutoEntityServiceConfig),
+    deps?: any[]
+  ): ModuleWithProviders<NgrxAutoEntityServiceModule> {
     return {
       ngModule: NgrxAutoEntityServiceModule,
-      providers: _provideAutoEntityService(config)
+      providers: _provideAutoEntityService(config, deps)
     };
   }
 }

--- a/projects/ngrx-auto-entity-service/src/lib/ngrx-auto-entity-service.module.ts
+++ b/projects/ngrx-auto-entity-service/src/lib/ngrx-auto-entity-service.module.ts
@@ -1,11 +1,8 @@
 import { ModuleWithProviders, NgModule } from '@angular/core';
-import { HttpClientModule } from '@angular/common/http';
 import { AutoEntityServiceConfig } from './config';
 import { _provideAutoEntityService } from './ngrx-auto-entity-service.provider';
 
-@NgModule({
-  imports: [HttpClientModule]
-})
+@NgModule({})
 export class NgrxAutoEntityServiceModule {
   static forRoot(config: AutoEntityServiceConfig): ModuleWithProviders<NgrxAutoEntityServiceModule>;
   static forRoot(config: () => AutoEntityServiceConfig): ModuleWithProviders<NgrxAutoEntityServiceModule>;
@@ -14,7 +11,7 @@ export class NgrxAutoEntityServiceModule {
   static forRoot(config: AutoEntityServiceConfig | (() => AutoEntityServiceConfig)): ModuleWithProviders<NgrxAutoEntityServiceModule> {
     return {
       ngModule: NgrxAutoEntityServiceModule,
-      providers: [..._provideAutoEntityService(config)]
+      providers: _provideAutoEntityService(config)
     };
   }
 }

--- a/projects/ngrx-auto-entity-service/src/lib/ngrx-auto-entity-service.module.ts
+++ b/projects/ngrx-auto-entity-service/src/lib/ngrx-auto-entity-service.module.ts
@@ -4,10 +4,13 @@ import { _provideAutoEntityService } from './ngrx-auto-entity-service.provider';
 
 @NgModule({})
 export class NgrxAutoEntityServiceModule {
+  /** @deprecated use {@link provideAutoEntityService} */
   static forRoot(config: AutoEntityServiceConfig): ModuleWithProviders<NgrxAutoEntityServiceModule>;
+  /** @deprecated use {@link provideAutoEntityService} */
   static forRoot(config: () => AutoEntityServiceConfig): ModuleWithProviders<NgrxAutoEntityServiceModule>;
-  /** @deprecated use `inject` to provide dependencies */
+  /** @deprecated use {@link provideAutoEntityService} */
   static forRoot(config: (...deps: any[]) => AutoEntityServiceConfig, deps: any[]): ModuleWithProviders<NgrxAutoEntityServiceModule>;
+  /** @deprecated use {@link provideAutoEntityService} */
   static forRoot(
     config: AutoEntityServiceConfig | (() => AutoEntityServiceConfig),
     deps?: any[]

--- a/projects/ngrx-auto-entity-service/src/lib/ngrx-auto-entity-service.provider.ts
+++ b/projects/ngrx-auto-entity-service/src/lib/ngrx-auto-entity-service.provider.ts
@@ -7,22 +7,33 @@ import { noop } from 'rxjs';
 declare const ngDevMode: unknown;
 
 /** @internal */
+export function _assertHttpClientProvided(): () => void {
+  const http = inject(HttpClient, { optional: true });
+  if (http == null) {
+    console.error("[NGRX-AES] ! No provider for HttpClient. Make sure `provideHttpClient()` is included in your application's providers.");
+  }
+  return noop;
+}
+
+/** @internal */
 export function _provideAutoEntityService(config: AutoEntityServiceConfig | (() => AutoEntityServiceConfig), deps?: any[]): Provider[] {
+  const providers: Provider[] = [];
+
+  if (typeof ngDevMode !== 'undefined' && ngDevMode) {
+    providers.push({
+      provide: APP_INITIALIZER,
+      useFactory: _assertHttpClientProvided,
+      multi: true
+    });
+  }
+
   return [
+    ...providers,
     EntityService,
     typeof config === 'function'
       ? { provide: AUTO_ENTITY_CONFIG, useFactory: config, deps }
       : { provide: AUTO_ENTITY_CONFIG, useValue: config }
   ];
-}
-
-/** @internal */
-export function _assertHttpClientProvided(): () => void {
-  const http = inject(HttpClient, { optional: true });
-  if (http == null) {
-    console.error("[NGRX-AES] ! No provider for HttpClient. Make sure `provideHttpClient()` is included in you application's providers.");
-  }
-  return noop;
 }
 
 /**
@@ -66,15 +77,5 @@ export function _assertHttpClientProvided(): () => void {
  * @returns A set of providers to set up an Auto-Entity Service.
  */
 export function provideAutoEntityService(config: AutoEntityServiceConfig | (() => AutoEntityServiceConfig)): EnvironmentProviders {
-  const providers: Provider[] = [];
-
-  if (typeof ngDevMode !== 'undefined' && ngDevMode) {
-    providers.push({
-      provide: APP_INITIALIZER,
-      useFactory: _assertHttpClientProvided,
-      multi: true
-    });
-  }
-
-  return makeEnvironmentProviders([...providers, ..._provideAutoEntityService(config)]);
+  return makeEnvironmentProviders(_provideAutoEntityService(config));
 }

--- a/projects/ngrx-auto-entity/src/lib/module.ts
+++ b/projects/ngrx-auto-entity/src/lib/module.ts
@@ -8,7 +8,7 @@ import {
   withoutExtraEffects
 } from './provider';
 
-// eslint-disable-next-line @typescript-eslint/naming-convention
+ 
 export interface NgRxAutoEntityModuleConfig {
   excludeEffects?: boolean;
 }
@@ -27,6 +27,7 @@ export class NgRxAutoEntityFeatureModule {}
 
 @NgModule({})
 export class NgrxAutoEntityModule {
+  /** @deprecated use {@link provideAutoEntityStore} */
   static forRoot(): ModuleWithProviders<NgRxAutoEntityRootModuleWithEffects> {
     return {
       ngModule: NgRxAutoEntityRootModuleWithEffects,
@@ -34,6 +35,7 @@ export class NgrxAutoEntityModule {
     };
   }
 
+  /** @deprecated use {@link provideAutoEntityStore} passing in {@link withoutEntityEffects} */
   static forRootNoEntityEffects(): ModuleWithProviders<NgRxAutoEntityRootModuleNoEntityEffects> {
     return {
       ngModule: NgRxAutoEntityRootModuleNoEntityEffects,
@@ -41,6 +43,7 @@ export class NgrxAutoEntityModule {
     };
   }
 
+  /** @deprecated use {@link provideAutoEntityStore} passing in {@link withoutEntityEffects} and {@link withoutExtraEffects} */
   static forRootNoEffects(): ModuleWithProviders<NgRxAutoEntityRootModuleNoEffects> {
     return {
       ngModule: NgRxAutoEntityRootModuleNoEffects,
@@ -48,6 +51,7 @@ export class NgrxAutoEntityModule {
     };
   }
 
+  /** @deprecated use {@link provideAutoEntityState} */
   static forFeature(): ModuleWithProviders<NgRxAutoEntityFeatureModule> {
     return {
       ngModule: NgRxAutoEntityFeatureModule,

--- a/projects/test-app/src/app/app.module.ts
+++ b/projects/test-app/src/app/app.module.ts
@@ -24,6 +24,7 @@ export class ConfigService {
 
 @NgModule({
   declarations: [AppComponent],
+  bootstrap: [AppComponent],
   imports: [
     CommonModule,
     BrowserModule,
@@ -37,7 +38,6 @@ export class ConfigService {
     { provide: Customer, useClass: EntityService },
     { provide: Account, useClass: EntityService },
     { provide: NGRX_AUTO_ENTITY_APP_STORE, useFactory: provideAppStore, deps: [Store] }
-  ],
-  bootstrap: [AppComponent]
+  ]
 })
 export class AppModule {}


### PR DESCRIPTION
#### Summary

- Adds documentation deprecating all module-based APIs, with their recommended replacements.
- Removes `HttpClientModule` as an import in the `NgRxAutoEntityModule`. Instead requiring the application to provide it using `provideHttpClient`.
- Fixes the missing `deps` parameter when registering the root module for Auto-Entity Service.