### PR TITLE
Fix AES Constructor

### DIFF
--- a/projects/ngrx-auto-entity-service/README.md
+++ b/projects/ngrx-auto-entity-service/README.md
@@ -20,6 +20,7 @@ NgRx Auto-Entity is compatible with the following versions.
 | NgRx Auto Entity Service | NgRx Auto Entity | Angular Core | NgRx        | RxJs |
 | ------------------------ | ---------------- | ------------ | ----------- | ---- |
 | 21.x                     | 21.x             | 21.x         | 21.x        | 7.x  |
+| 20.x                     | 20.x             | 20.x         | 20.x        | 7.x  |
 | 19.x                     | 19.x             | 19.x         | 19.x        | 7.x  |
 | 18.x                     | 18.x             | 18.x         | 18.x        | 7.x  |
 | 17.x                     | 17.x             | 17.x         | 17.x        | 7.x  |

--- a/projects/ngrx-auto-entity-service/package.json
+++ b/projects/ngrx-auto-entity-service/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "21.0.0-alpha.1",
+  "version": "21.1.0-alpha.1",
   "name": "@briebug/ngrx-auto-entity-service",
   "description": "Prefabricated reusable Entity Service for NgRx Auto-Entity",
   "license": "SEE LICENSE IN LICENSE.md",
@@ -39,7 +39,7 @@
     "@angular/common": "^21.0.0",
     "@angular/core": "^21.0.0",
     "rxjs": "^7.0.0",
-    "@briebug/ngrx-auto-entity": "^21.0.0"
+    "@briebug/ngrx-auto-entity": "^21.1.0"
   },
   "sideEffects": false
 }

--- a/projects/ngrx-auto-entity-service/src/lib/entity.service.spec.ts
+++ b/projects/ngrx-auto-entity-service/src/lib/entity.service.spec.ts
@@ -1,5 +1,8 @@
 import { TestBed } from '@angular/core/testing';
 import { EntityService } from './entity.service';
+import { provideHttpClientTesting } from '@angular/common/http/testing';
+import { AUTO_ENTITY_CONFIG, AutoEntityServiceConfig } from './config';
+import { HttpClient, provideHttpClient } from '@angular/common/http';
 
 describe('EntityService', () => {
   let service: EntityService;
@@ -18,5 +21,42 @@ describe('EntityService', () => {
 
   it('should be created', () => {
     expect(service).toBeTruthy();
+  });
+});
+
+describe('EntityService', () => {
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [
+        provideHttpClient(),
+        provideHttpClientTesting(),
+        {
+          provide: AUTO_ENTITY_CONFIG,
+          useValue: {
+            urlPrefix: 'http://example.com/default'
+          }
+        }
+      ]
+    });
+  });
+
+  it('should allow instantiation with an HttpClient and config', () => {
+    const http = TestBed.inject(HttpClient);
+    const config = {
+      urlPrefix: 'http://example.com/custom'
+    } satisfies AutoEntityServiceConfig;
+    const service = TestBed.runInInjectionContext(() => new EntityService(http, config));
+    expect(service).toBeDefined();
+    expect(service).toHaveProperty('http');
+    expect(service).toHaveProperty('config');
+    expect((service as any).config.urlPrefix).toBe('http://example.com/custom');
+  });
+
+  it('should allow instantiation without arguments', () => {
+    const service = TestBed.runInInjectionContext(() => new EntityService());
+    expect(service).toBeDefined();
+    expect(service).toHaveProperty('http');
+    expect(service).toHaveProperty('config');
+    expect((service as any).config.urlPrefix).toBe('http://example.com/default');
   });
 });

--- a/projects/ngrx-auto-entity-service/src/lib/entity.service.ts
+++ b/projects/ngrx-auto-entity-service/src/lib/entity.service.ts
@@ -1,6 +1,12 @@
 import { HttpClient } from '@angular/common/http';
-import { Injectable, inject } from '@angular/core';
-import { EntityIdentity, getKeyFromModel, IAutoEntityService, IEntityInfo } from '@briebug/ngrx-auto-entity';
+import { Injectable, inject, Inject } from '@angular/core';
+import {
+  EntityIdentity,
+  getKeyFromModel,
+  IAutoEntityService,
+  IEntityInfo,
+  ɵNAE_UNDEFINED as NAE_UNDEFINED
+} from '@briebug/ngrx-auto-entity';
 import { first, from, Observable, of, switchMap } from 'rxjs';
 import { map } from 'rxjs/operators';
 import { buildUrl, resolveRetryCriteria } from './entity.service.utils';
@@ -9,8 +15,16 @@ import { EntityCriteria } from './critera.model';
 
 @Injectable()
 export class EntityService implements IAutoEntityService<any> {
-  private readonly http = inject(HttpClient);
-  private readonly config = inject<AutoEntityServiceConfig>(AUTO_ENTITY_CONFIG);
+  /** @deprecated Use the empty constructor instead */
+  // eslint-disable-next-line @angular-eslint/prefer-inject
+  constructor(http: HttpClient, config: AutoEntityServiceConfig);
+  constructor();
+  constructor(
+    // eslint-disable-next-line @angular-eslint/prefer-inject
+    @Inject(NAE_UNDEFINED) private readonly http = inject(HttpClient),
+    // eslint-disable-next-line @angular-eslint/prefer-inject
+    @Inject(NAE_UNDEFINED) private readonly config = inject<AutoEntityServiceConfig>(AUTO_ENTITY_CONFIG)
+  ) {}
 
   protected getUrlPrefix(operation: string, info: IEntityInfo, criteria?: EntityCriteria): Observable<string> {
     return typeof this.config.urlPrefix === 'string' ? of(this.config.urlPrefix) : from(this.config.urlPrefix(operation, info, criteria));

--- a/projects/ngrx-auto-entity/README.md
+++ b/projects/ngrx-auto-entity/README.md
@@ -36,6 +36,7 @@ NgRx Auto-Entity is compatible with the following versions.
 | NgRx Auto Entity | Angular Core | NgRx        | RxJs |
 | ---------------- | ------------ | ----------- | ---- |
 | 21.x             | 21.x         | 21.x        | 7.x  |
+| 20.x             | 20.x         | 20.x        | 7.x  |
 | 19.x             | 19.x         | 19.x        | 7.x  |
 | 18.x             | 18.x         | 18.x        | 7.x  |
 | 17.x             | 17.x         | 17.x        | 7.x  |

--- a/projects/ngrx-auto-entity/package.json
+++ b/projects/ngrx-auto-entity/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "21.0.0",
+  "version": "21.1.0",
   "name": "@briebug/ngrx-auto-entity",
   "description": "Automatic Entity State and Facades for NgRx. Simplifying reactive state!",
   "license": "SEE LICENSE IN LICENSE.md",

--- a/projects/ngrx-auto-entity/src/lib/util/facade-builder.ts
+++ b/projects/ngrx-auto-entity/src/lib/util/facade-builder.ts
@@ -24,10 +24,7 @@ import { TNew } from '../actions/model-constructor';
 import { NGRX_AUTO_ENTITY_APP_STORE } from '../effects/if-necessary-operator-utils';
 import { Observable } from 'rxjs';
 import { IEntityDictionary } from './entity-state';
-
-const NAE_UNDEFINED = new InjectionToken<TNew<any>>('@briebug/ngrx-auto-entity Undefined', {
-  factory: () => undefined
-});
+import { NAE_UNDEFINED } from './util-di';
 
 /**
  * Builds a new facade class for the specified entity model and parent state.

--- a/projects/ngrx-auto-entity/src/lib/util/util-di.ts
+++ b/projects/ngrx-auto-entity/src/lib/util/util-di.ts
@@ -1,0 +1,7 @@
+import { InjectionToken } from '@angular/core';
+
+/** @internal */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export const NAE_UNDEFINED = new InjectionToken<any>('@briebug/ngrx-auto-entity Undefined', {
+  factory: () => undefined
+});

--- a/projects/ngrx-auto-entity/src/public_api.ts
+++ b/projects/ngrx-auto-entity/src/public_api.ts
@@ -200,3 +200,6 @@ export {
   UpsertManyEffect
 } from './lib/effects/effects-cud-discrete';
 export { NGRX_AUTO_ENTITY_APP_STORE } from './lib/effects/if-necessary-operator-utils';
+
+/* internal */
+export { NAE_UNDEFINED as ɵNAE_UNDEFINED } from './lib/util/util-di';


### PR DESCRIPTION
#### Overview

The constructor for AES was modified after 19.0.0-alpha.1 to use `inject` instead of constructor-based injection. The change failed to account for child classes. This added the constructor back with optional arguments to support code before the update.